### PR TITLE
Support functions on generic types

### DIFF
--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -8,7 +8,7 @@ jobs:
   build_library:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-14, macos-13, macos-12]
+        os: [ubuntu-22.04, macos-14, macos-13, macos-12]
         nixShell: [shell.nix, shell-902.nix]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   nix-build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-14, macos-13, macos-12]
+        os: [ubuntu-22.04, macos-14, macos-13, macos-12]
         package: [dump-decls-lib, dump-decls-exe]
         nix_file: [build.ghc96.nix, build.ghc98.nix]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix-build ${{ matrix.package }}/${{ matrix.nix_file }}
       - name: Test run of 'dump-decls' executable
         if: ${{ matrix.package == 'dump-decls-exe' }}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,76 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Warnings currently triggered by your code
+- ignore: {name: "Avoid lambda"} # 1 hint
+- ignore: {name: "Eta reduce"} # 3 hints
+- ignore: {name: "Move brackets to avoid $"} # 1 hint
+- ignore: {name: "Redundant $"} # 3 hints
+- ignore: {name: "Unused LANGUAGE pragma"} # 1 hint
+- ignore: {name: "Use camelCase"} # 1 hint
+- ignore: {name: "Use concatMap"} # 1 hint
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+# The hints are named by the string they display in warning messages.
+# For example, if you see a warning starting like
+#
+# Main.hs:116:51: Warning: Redundant ==
+#
+# You can refer to that hint with `{name: Redundant ==}` (see below).
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/dump-decls-exe/dump-decls-exe.cabal
+++ b/dump-decls-exe/dump-decls-exe.cabal
@@ -11,6 +11,7 @@ library
     exposed-modules: Exe
     hs-source-dirs: exe
     build-depends:    base, dump-decls-lib, ghc, containers, text, bytestring, exceptions, ghc-paths
+    ghc-options:      -Wall
 
 executable dump-decls
     main-is:          Main.hs

--- a/dump-decls-exe/dump-decls-exe.cabal
+++ b/dump-decls-exe/dump-decls-exe.cabal
@@ -10,7 +10,7 @@ copyright:          (c) 2023 Ben Gamari
 library
     exposed-modules: Exe
     hs-source-dirs: exe
-    build-depends:    base, dump-decls-lib, ghc, containers, text, bytestring, exceptions, ghc-paths
+    build-depends:    base, dump-decls-lib, ghc, containers, text, bytestring, exceptions, ghc-paths, transformers
     ghc-options:      -Wall
 
 executable dump-decls

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Exe
 ( main
+, StdoutJsonFormat
 )
 where
 
@@ -57,6 +58,11 @@ import Data.Functor ((<&>), void)
 import qualified Data.Text.IO as TIO
 import qualified GHC.Driver.Session
 
+-- | The output printed to stdout can be parsed as JSON into this data type.
+--
+--   Using e.g. @Data.Aeson.decode :: Data.ByteString.Lazy.ByteString -> Maybe StdoutJsonFormat@
+type StdoutJsonFormat = [Json.DeclarationMapJson T.Text]
+
 main :: IO ()
 main = do
   args <- getArgs
@@ -79,7 +85,7 @@ main = do
           , "failed to parse" <> "."
           , renderTyConParseError err
           ]
-  Json.streamPrintJsonList declarationMapJsonList
+  Json.streamPrintJsonList (declarationMapJsonList :: StdoutJsonFormat)
   where
     reallyCatch :: IO a -> IO (Either Control.Exception.SomeException a)
     reallyCatch ioAction =

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -15,9 +15,7 @@ import Types
 import qualified Json
 import Types.Doodle -- TODO
 import GHC hiding (moduleName)
-import qualified GHC.Paths
 import GHC.Core.Type (splitFunTys, expandTypeSynonyms, isLiftedTypeKind, isConstraintKind, returnsConstraintKind, typeKind)
-import GHC.Driver.Ppr (showSDocForUser)
 import GHC.Unit.State (lookupUnitId, lookupPackageName, pprWithUnitState)
 import GHC.Unit.Info (UnitInfo, unitExposedModules, unitId, PackageName(..))
 import GHC.Unit.Types (UnitId)
@@ -29,12 +27,11 @@ import GHC.Types.Name (nameOccName, getSrcLoc)
 import GHC.Types.Name.Occurrence (OccName)
 import GHC.Types.Var (varName, varType, VarBndr (Bndr), tyVarKind)
 import Data.Function (on)
-import Data.List (sortBy, foldl')
+import Data.List (sortBy)
 import System.Environment (getArgs)
-import Control.Monad (forM, forM_, unless)
+import Control.Monad (forM, forM_)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import qualified Data.List.NonEmpty as NE
 import qualified System.Exit as Exit
 import Control.Monad.IO.Class (liftIO, MonadIO)
 import GHC.IO.Unsafe (unsafeInterleaveIO)
@@ -48,18 +45,14 @@ import GHC.Core.TyCo.Rep (Type(..), KindOrType)
 import GHC.Core.TyCon (isUnboxedTupleTyCon, isBoxedTupleTyCon, isTupleTyCon)
 import GHC.Builtin.Names (listTyConKey, getUnique)
 import qualified Data.Text as T
-import Data.Bifunctor (bimap, first)
-import GHC.Stack (HasCallStack)
-import Data.Functor.Identity (Identity(Identity))
-import Debug.Trace (trace)
+import Data.Bifunctor (first)
 import qualified Types.Forall as Forall
-import Data.Either (fromLeft, fromRight)
+import Data.Either (fromLeft)
 import Data.Functor ((<&>), void)
 import qualified Data.Text.IO as TIO
 import qualified GHC.Driver.Session
 import qualified Types.Doodle as Doodle
-import Data.Void (Void, absurd)
-import Control.Monad.Trans.Except (ExceptT, throwE, except, withExcept, withExceptT, Except)
+import Control.Monad.Trans.Except (ExceptT, throwE, except, withExceptT, Except, runExcept)
 
 -- | The output printed to stdout can be parsed as JSON into this data type.
 --
@@ -77,14 +70,13 @@ main = do
       runGhc' ghcLibDir (getPprFun first_package_name) >>= either (fail . show) (\pprFun -> pure $ (pprFun, ghcLibDir, pkg_names))
   lst <- forM pkg_names $ \pkg_nm -> do
     unsafeInterleaveIO $ runGhc' ghcLibDir (getDefinitions (pprFun . pprSuppressVarKinds) pkg_nm) >>= logErrors
-  let declarationMapJsonList = map (declarationMapToJson (pprFun . pprSuppressVarKinds) absurd) (catMaybes lst)
+  let declarationMapJsonList = map (declarationMapToJson (pprFun . pprSuppressVarKinds)) (catMaybes lst)
   forM_ declarationMapJsonList $ \declarationMapJson -> do
     let errors = Map.assocs $ Map.assocs <$> Json.moduleDeclarations_mapFail (Json.declarationMapJson_moduleDeclarations declarationMapJson)
     forM_ errors $ \(modName, pkgErrs) ->
       forM_ pkgErrs $ \(defnName, err) ->
         logError $ T.unpack $ T.unwords
           [ "WARNING:"
-          -- , T.pack $ show (tyConParseErrorInput err) -- WIP
           , "failed to parse" <> "."
           , renderFgError err
           ]
@@ -140,7 +132,7 @@ getPprFun pkg_nm = do
           blahTodo sDocContext' = sDocContext'{sdocSuppressVarKinds = True, sdocPrintExplicitKinds = False, sdocStarIsType = True}
       in renderWithContext (blahTodo sDocContext) doc'
 
-getDefinitions :: (SDoc -> T.Text) -> String -> Ghc (Maybe (DeclarationMap Void))
+getDefinitions :: (SDoc -> T.Text) -> String -> Ghc (Maybe (DeclarationMap (Either FgError SomeFunction)))
 getDefinitions pprFun pkg_nm = do
   _ <- setDFlags pkg_nm
   unit_state <- hsc_units <$> getSession
@@ -157,8 +149,8 @@ getDefinitions pprFun pkg_nm = do
     let blah = concat $ map (ppFunctionMap pprFun) (Map.elems defs)
     void $ liftIO $ mapM (TIO.hPutStrLn IO.stderr) blah
   let f :: Map ModuleName FunctionMap
-        -> Map ModuleName (Map Name Doodle.SomeFunction)
-      f = fmap (fmap eitherToSomeFunction)
+        -> Map ModuleName (Map Name (Either FgError Doodle.SomeFunction))
+      f = fmap (fmap (fmap eitherToSomeFunction . runExcept))
   pure $ DeclarationMap unit_id . f <$> mDefinitions
 
 ppFunctionMap
@@ -168,7 +160,7 @@ ppFunctionMap
 ppFunctionMap pprFun fm = catMaybes $
    -- WIP: ignore non-forall functions for now
   Map.toList fm <&> \(name, fun) ->
-    either (const Nothing) (ppTodo name) fun
+    either (const Nothing) (either (const Nothing) (ppTodo name)) (runExcept fun)
   where
     ppTodo name !fun = Just $
       T.unwords
@@ -282,7 +274,8 @@ reportModuleDecls pprFun unit_id modl_nm = do
 -- TODO: postpone conversion of GHC 'Type' to 'FgType'? Or just use 'funtionTypeExpandAndConvertToFgType' in here?
 parseType
   :: forall m.
-     (SDoc -> T.Text)
+     (Traversable m, Monad m)
+  => (SDoc -> T.Text)
   -> UnitId
   -> (ModuleName, Name)
   -> Type
@@ -369,8 +362,7 @@ data DeclarationMap ty = DeclarationMap
   }
 
 declarationMapToJson
-  :: forall ty.
-     (SDoc -> T.Text)
+  :: (SDoc -> T.Text)
   -> DeclarationMap (Either FgError SomeFunction)
   -> Json.DeclarationMapJson T.Text
 declarationMapToJson pprFun dm =
@@ -378,8 +370,8 @@ declarationMapToJson pprFun dm =
     eitherMap :: Map T.Text (Map T.Text (Either FgError SomeFunction))
     eitherMap = mapMap (declarationMap_moduleDeclarations dm) $ \(modName, nameMap) ->
       ( fullyQualify' modName
-      , mapMapMaybe nameMap $ \(name, either') -> — TODO: no Maybe
-          (noQualify' name, either')
+      , mapMapMaybe nameMap $ \(name, either') ->
+          (noQualify' name, Just either') -- WIP: no Maybe
       )
 
   in Json.DeclarationMapJson

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -15,9 +15,9 @@ import qualified Json
 import Types.Doodle -- TODO
 import GHC hiding (moduleName)
 import qualified GHC.Paths
-import GHC.Core.Type (splitFunTys, expandTypeSynonyms)
+import GHC.Core.Type (splitFunTys, expandTypeSynonyms, isLiftedTypeKind, isConstraintKind, returnsConstraintKind, typeKind)
 import GHC.Driver.Ppr (showSDocForUser)
-import GHC.Unit.State (lookupUnitId, lookupPackageName)
+import GHC.Unit.State (lookupUnitId, lookupPackageName, pprWithUnitState)
 import GHC.Unit.Info (UnitInfo, unitExposedModules, unitId, PackageName(..))
 import GHC.Unit.Types (UnitId)
 import GHC.Data.FastString (fsLit)
@@ -26,7 +26,7 @@ import GHC.Utils.Outputable hiding (sep, (<>))
 import GHC.Types.TyThing (tyThingParent_maybe)
 import GHC.Types.Name (nameOccName, getSrcLoc)
 import GHC.Types.Name.Occurrence (OccName)
-import GHC.Types.Var (varName, varType, VarBndr (Bndr))
+import GHC.Types.Var (varName, varType, VarBndr (Bndr), tyVarKind)
 import Data.Function (on)
 import Data.List (sortBy, foldl')
 import System.Environment (getArgs)
@@ -55,6 +55,7 @@ import qualified Types.Forall as Forall
 import Data.Either (fromLeft, fromRight)
 import Data.Functor ((<&>), void)
 import qualified Data.Text.IO as TIO
+import qualified GHC.Driver.Session
 
 main :: IO ()
 main = do
@@ -66,8 +67,8 @@ main = do
     ghcLibDir : (first_package_name : _) ->
       runGhc' ghcLibDir (getPprFun first_package_name) >>= either (fail . show) (\lol -> pure $ (lol, ghcLibDir))
   lst <- forM pkg_names $ \pkg_nm -> do
-    unsafeInterleaveIO $ runGhc' ghcLibDir (getDefinitions pprFun pkg_nm) >>= logErrors
-  let declarationMapJsonList = map (declarationMapToJson pprFun) (catMaybes lst)
+    unsafeInterleaveIO $ runGhc' ghcLibDir (getDefinitions (pprFun . pprSuppressVarKinds) pkg_nm) >>= logErrors
+  let declarationMapJsonList = map (declarationMapToJson (pprFun . pprSuppressVarKinds)) (catMaybes lst)
   forM_ declarationMapJsonList $ \declarationMapJson -> do
     let errors = Map.assocs $ Map.assocs <$> Json.moduleDeclarations_mapFail (Json.declarationMapJson_moduleDeclarations declarationMapJson)
     forM_ errors $ \(modName, pkgErrs) ->
@@ -121,7 +122,14 @@ getPprFun pkg_nm = do
   dflags <- setDFlags pkg_nm
   unit_state <- hsc_units <$> getSession
   name_ppr_ctx <- GHC.getNamePprCtx
-  pure $ T.pack . showSDocForUser dflags unit_state name_ppr_ctx
+  pure $ T.pack . showSDocForUser' dflags unit_state name_ppr_ctx
+  where
+    showSDocForUser' dflags unit_state name_ppr_ctx doc =
+      let sty  = mkUserStyle name_ppr_ctx AllTheWay
+          doc' = GHC.Unit.State.pprWithUnitState unit_state doc
+          sDocContext = GHC.Driver.Session.initSDocContext dflags sty
+          blahTodo sDocContext' = sDocContext'{sdocSuppressVarKinds = True, sdocPrintExplicitKinds = False, sdocStarIsType = True}
+      in renderWithContext (blahTodo sDocContext) doc'
 
 getDefinitions :: (SDoc -> T.Text) -> String -> Ghc (Maybe DeclarationMap)
 getDefinitions pprFun pkg_nm = do
@@ -252,7 +260,7 @@ parseType pprFun package dbg tyInit =
   case splitFunTys tyInit of
     ([], res) ->
       case res of
-        ForAllTy bndr ty' ->
+        ForAllTy bndr ty' | isTypeKind bndr ->
           Right <$> goForall (parseForall Nothing bndr) ty'
         _ -> Nothing
     ([_], _) ->
@@ -263,11 +271,10 @@ parseType pprFun package dbg tyInit =
       case splitFunTys ty of
         ([], res) ->
           case res of
-            ForAllTy bndr ty' -> do
-              let forall' = parseForall (Just forall_) bndr
-              goForall forall' ty'
+            ForAllTy bndr ty' | isTypeKind bndr -> do
+              goForall (parseForall (Just forall_) bndr) ty'
             _ -> Nothing
-        ([arg], res) -> do
+        ([arg], res) | not (returnsConstraintKind $ GHC.Core.Type.typeKind (scaledThing arg)) -> do
             arg' <- toFgType' pprFun $ scaledThing arg
             res' <- toFgType' pprFun res
             let eResult = do
@@ -305,7 +312,7 @@ parseType pprFun package dbg tyInit =
             eResult
         _ -> Nothing
 
-    parseForall mForall (Bndr tyCoVar forAllTyFlag) =
+    parseForall mForall (Bndr tyCoVar _) =
       let mkForall = maybe (Right . Forall.singleton) (\forall' -> (`Forall.appendTyVar` forall')) mForall
           tyVarName = pprFun (ppr tyCoVar) -- WIP: correct?
           eForall = mkForall tyVarName
@@ -313,6 +320,10 @@ parseType pprFun package dbg tyInit =
 
     throwError showable =
       error $ show showable ++ " -- " ++ T.unpack (pprFun $ ppr tyInit)
+
+    -- is kind *
+    isTypeKind (Bndr tyVar _) =
+      isLiftedTypeKind (tyVarKind tyVar) && not (isConstraintKind $ tyVarKind tyVar)
 
 data DeclarationMap = DeclarationMap
   { declarationMap_package :: UnitId
@@ -423,6 +434,10 @@ tyConToFgTyCon pprFun package (modName, functionName) tyCon =
       , tyConParseErrorSrcLoc = pprFun (ppr $ getSrcLoc tyCon)
       }
 
+pprSuppressVarKinds :: SDoc -> SDoc
+pprSuppressVarKinds =
+  updSDocContext (\sDocContext -> sDocContext{sdocSuppressVarKinds = True, sdocPrintExplicitKinds = False})
+
 fullyQualify :: Outputable a => a -> SDoc
 fullyQualify =
   withUserStyle fullyQualify' AllTheWay . ppr
@@ -496,7 +511,7 @@ toFgType' pprFun ty =
     go = \case
       TyConApp tyCon tyConList -> -- WIP: ignore unless only Type kind(s) -- e.g. no Constraints
         tyConAppToFgTypeTyCon go tyCon tyConList
-      TyVarTy tyVar -> -- WIP: ignore unless only Type kind(s) -- e.g. no kind variables
+      TyVarTy tyVar ->
         pure $ FgType_TyConApp (Right tyVar) []
       appTy@AppTy{} -> do
         -- Flatten nested AppTy's. Ie. converting nested AppTy's into (1) the "function" type variable and (2) the "argument" type variable(s)/constructor(s).

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -71,15 +71,6 @@ main = do
   lst <- forM pkg_names $ \pkg_nm -> do
     unsafeInterleaveIO $ runGhc' ghcLibDir (getDefinitions (pprFun . pprSuppressVarKinds) pkg_nm) >>= logErrors
   let declarationMapJsonList = map (declarationMapToJson (pprFun . pprSuppressVarKinds)) (catMaybes lst)
-  forM_ declarationMapJsonList $ \declarationMapJson -> do
-    let errors = Map.assocs $ Map.assocs <$> Json.moduleDeclarations_mapFail (Json.declarationMapJson_moduleDeclarations declarationMapJson)
-    forM_ errors $ \(modName, pkgErrs) ->
-      forM_ pkgErrs $ \(defnName, err) ->
-        logError $ T.unpack $ T.unwords
-          [ "WARNING:"
-          , "failed to parse" <> "."
-          , renderFgError err
-          ]
   Json.streamPrintJsonList (declarationMapJsonList :: StdoutJsonFormat)
   where
     reallyCatch :: IO a -> IO (Either Control.Exception.SomeException a)

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -494,9 +494,9 @@ toFgType' pprFun ty =
   go ty
   where
     go = \case
-      TyConApp tyCon tyConList ->
+      TyConApp tyCon tyConList -> -- WIP: ignore unless only Type kind(s) -- e.g. no Constraints
         tyConAppToFgTypeTyCon go tyCon tyConList
-      TyVarTy tyVar ->
+      TyVarTy tyVar -> -- WIP: ignore unless only Type kind(s) -- e.g. no kind variables
         pure $ FgType_TyConApp (Right tyVar) []
       appTy@AppTy{} -> do
         -- Flatten nested AppTy's. Ie. converting nested AppTy's into (1) the "function" type variable and (2) the "argument" type variable(s)/constructor(s).

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -144,16 +144,17 @@ ppFunctionMap
   :: (SDoc -> T.Text)
   -> FunctionMap
   -> [T.Text]
-ppFunctionMap pprFun fm = catMaybes $ -- WIP: ignore non-forall functions for now
+ppFunctionMap pprFun fm = catMaybes $ -- WIP: ignore non-forall functions for now -- WIP: ignore non-forall functions for now
+   -- WIP: ignore non-forall functions for now
   Map.toList fm <&> \(name, fun) ->
     either (const Nothing) (ppTodo name) fun
   where
-    ppTodo name fun = Just $
-      T.unwords
-        [ pprFun (ppr name)
-        , "::"
-        , prettyPrintFTF fun
-        ]
+    ppTodo name !fun = Nothing --  Just $
+      -- T.unwords
+      --   [ pprFun (ppr name)
+      --   , "::"
+      --   , prettyPrintFTF fun
+      --   ]
 
 prettyPrintFunction
   :: Either
@@ -227,7 +228,6 @@ reportModuleDecls pprFun unit_id modl_nm = do
     things <- mapM GHC.lookupName sorted_names
     let contents =
             [ (varName _id, blah)
-            -- Json.FunctionType (scaledThing arg) res
             | Just thing <- things
             , AnId _id <- [thing]
             , Just blah <- [parseType pprFun unit_id (modl_nm, varName _id) (varType _id)]
@@ -237,8 +237,6 @@ reportModuleDecls pprFun unit_id modl_nm = do
                 _ -> True
             ]
     pure $ Map.fromList contents
-
-type Lol = Type
 
 parseType
   :: (SDoc -> T.Text)
@@ -275,13 +273,21 @@ parseType pprFun package dbg tyInit =
             let eResult = do
                   arg'' <- traverse (tyConOrTyVarTODO pprFun package dbg forall_) arg'
                   res'' <- traverse (tyConOrTyVarTODO pprFun package dbg forall_) res'
-                  pure $ FunctionTypeForall forall_ arg'' res''
+                  let debugPrintDiff ftf =
+                        let ftfTxt = prettyPrintFTF ftf
+                            ftfTxtGhc = pprFun (ppr tyInit)
+                        in if ftfTxt /= ftfTxtGhc
+                          then T.unpack ("DIFF: " <> ftfTxt <> "\n      " <> ftfTxtGhc <> "\n") `trace` ftf
+                          else ftf
+                  pure $ (if doDebugPrintDiff then debugPrintDiff else id) $ FunctionTypeForall forall_ arg'' res''
             pure $
               either
               throwError -- WIP: don't throw exception
               id
               eResult
         (_, _) -> Nothing
+
+    doDebugPrintDiff = True
 
     goSimple ty =
       case splitFunTys ty of
@@ -504,10 +510,12 @@ toFgType' pprFun ty =
       TyVarTy tyVar ->
         pure $ FgType_TyConApp (Right tyVar) []
       appTy@AppTy{} -> do
+        -- Flatten nested AppTy's. Ie. converting nested AppTy's into (1) the "function" type variable and (2) the "argument" type variable(s)/constructor(s).
+        -- E.g. from "((f a) b) c" to "FgType_TyConApp (Right f) [a, b, c]"
         let goAppTy
-              :: [FgType (Either TyCon TyVar)] -- argument accumulator
-              -> Type -- first argument to 'AppTy'
-              -> Maybe (TyVar, [FgType (Either TyCon TyVar)]) -- ("function" type variable, arguments)
+              :: [FgType (Either TyCon TyVar)] -- "argument" accumulator. accumulates the second argument to "AppTy" (ie. the "argument" type).
+              -> Type -- the first argument to 'AppTy' (ie. the "function" type variable)
+              -> Maybe (TyVar, [FgType (Either TyCon TyVar)]) -- ("function" type variable, argument type variables/constructors)
             goAppTy acc = \case
               TyVarTy tyVar -> Just (tyVar, acc)
               AppTy fun2 arg2 -> do
@@ -515,7 +523,6 @@ toFgType' pprFun ty =
                 goAppTy (arg2' : acc) fun2
               TyConApp{} ->
                 -- 'TyConApp' is not allowed as first argument to 'AppTy'.
-                -- TODO: why is 'FgType_TyConApp (Right tyVar)' not a TyConApp and everything else is?
                 -- See docs: https://hackage.haskell.org/package/ghc-9.6.1/docs/GHC-Core-TyCo-Rep.html#v:AppTy
                 error $ unwords
                   [ "Unexpected TyConApp as first argument to AppTy:"

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -68,7 +68,7 @@ main = do
       runGhc' ghcLibDir (getPprFun first_package_name) >>= either (fail . show) (\pprFun -> pure $ (pprFun, ghcLibDir, pkg_names))
   lst <- forM pkg_names $ \pkg_nm -> do
     unsafeInterleaveIO $ runGhc' ghcLibDir (getDefinitions (pprFun . pprSuppressVarKinds) pkg_nm) >>= logErrors
-  let declarationMapJsonList = map (declarationMapToJson (pprFun . pprSuppressVarKinds)) (catMaybes lst)
+  let declarationMapJsonList = map (declarationMapToJson (pprFun . pprSuppressVarKinds) (Just . Right)) (catMaybes lst)
   forM_ declarationMapJsonList $ \declarationMapJson -> do
     let errors = Map.assocs $ Map.assocs <$> Json.moduleDeclarations_mapFail (Json.declarationMapJson_moduleDeclarations declarationMapJson)
     forM_ errors $ \(modName, pkgErrs) ->
@@ -90,8 +90,8 @@ main = do
             Just eAsync -> logError ("Caught async exception: " ++ show eAsync) >> Ex.throwIO eAsync
 
     logErrors
-      :: Either Control.Monad.Catch.SomeException (Maybe DeclarationMap)
-      -> IO (Maybe DeclarationMap)
+      :: Either Control.Monad.Catch.SomeException (Maybe (DeclarationMap ty))
+      -> IO (Maybe (DeclarationMap ty))
     logErrors = \case
       Left ex -> logError (show ex) >> pure Nothing
       Right res -> pure res
@@ -131,7 +131,7 @@ getPprFun pkg_nm = do
           blahTodo sDocContext' = sDocContext'{sdocSuppressVarKinds = True, sdocPrintExplicitKinds = False, sdocStarIsType = True}
       in renderWithContext (blahTodo sDocContext) doc'
 
-getDefinitions :: (SDoc -> T.Text) -> String -> Ghc (Maybe DeclarationMap)
+getDefinitions :: (SDoc -> T.Text) -> String -> Ghc (Maybe (DeclarationMap (FgType (FgTyCon T.Text))))
 getDefinitions pprFun pkg_nm = do
   _ <- setDFlags pkg_nm
   unit_state <- hsc_units <$> getSession
@@ -146,16 +146,16 @@ getDefinitions pprFun pkg_nm = do
   forM_ mDefinitions $ \defs -> do
     let blah = concat $ map (ppFunctionMap pprFun) (Map.elems defs)
     void $ liftIO $ mapM (TIO.hPutStrLn IO.stderr) blah
-  let f :: Map ModuleName FunctionMap -> Map ModuleName (Map Name (Json.FunctionType Type))
-      f = fmap $ (Map.mapMaybe $ either Just (const Nothing))
-  pure $ DeclarationMap unit_id <$> Nothing
-  --
+  let f :: Map ModuleName FunctionMap -> Map ModuleName (Map Name (Json.FunctionType (FgType (FgTyCon T.Text))))
+      f = fmap $ Map.mapMaybe $ either Just (const Nothing)
+  pure $ DeclarationMap unit_id . f <$> mDefinitions
 
 ppFunctionMap
   :: (SDoc -> T.Text)
   -> FunctionMap
   -> [T.Text]
-ppFunctionMap pprFun fm = catMaybes $ -- WIP: ignore non-forall functions for now
+ppFunctionMap pprFun fm = catMaybes $
+   -- WIP: ignore non-forall functions for now
   Map.toList fm <&> \(name, fun) ->
     either (const Nothing) (ppTodo name) fun
   where
@@ -255,7 +255,9 @@ reportModuleDecls pprFun unit_id modl_nm = do
             [ (varName _id, blah)
             | Just thing <- things
             , AnId _id <- [thing]
-            , Just blah <- [parseType pprFun unit_id (modl_nm, varName _id) (varType _id)]
+            , Just blah <-
+                let ty = expandTypeSynonyms $ varType _id -- NOTE: we need to expand type synonyms because two types are considered equal only if their 'FgType' representations are equal (==). And a type synonym is a distinct 'TyConApp', which means it'll become a distinct 'FgType'.
+                in [parseType pprFun unit_id (modl_nm, varName _id) ty]
             , case tyThingParent_maybe thing of
                 Just parent
                   | is_exported (getOccName parent) -> False
@@ -345,23 +347,25 @@ parseType pprFun package dbg tyInit =
     isTypeKind (Bndr tyVar _) =
       isLiftedTypeKind (tyVarKind tyVar) && not (isConstraintKind $ tyVarKind tyVar)
 
-data DeclarationMap = DeclarationMap
+data DeclarationMap ty = DeclarationMap
   { declarationMap_package :: UnitId
-  , declarationMap_moduleDeclarations :: Map ModuleName (Map Name (Json.FunctionType Type))
+  , declarationMap_moduleDeclarations :: Map ModuleName (Map Name (Json.FunctionType ty))
     -- ^ -- A map from a module name to the declarations in that module
   }
 
 declarationMapToJson
-  :: (SDoc -> T.Text)
-  -> DeclarationMap
+  :: forall ty.
+     (SDoc -> T.Text)
+  -> (ty -> Maybe (Either TyConParseError (FgType (FgTyCon T.Text))))
+  -> DeclarationMap ty
   -> Json.DeclarationMapJson T.Text
-declarationMapToJson pprFun dm =
+declarationMapToJson pprFun tyToFgType dm =
   let
     eitherMap :: Map T.Text (Map T.Text (Either TyConParseError (Json.FunctionType (FgType (FgTyCon T.Text)))))
     eitherMap = mapMap (declarationMap_moduleDeclarations dm) $ \(modName, nameMap) ->
       ( fullyQualify' modName
       , mapMapMaybe nameMap $ \(name, functionType) ->
-          (noQualify' name, funtionTypeExpandAndConvertToFgType (modName, name) functionType)
+          (noQualify' name, funtionTypeConvertToFgType (modName, name) functionType)
       )
 
   in Json.DeclarationMapJson
@@ -388,19 +392,20 @@ declarationMapToJson pprFun dm =
     mapMapMaybe :: Ord k' => Map k a -> ((k, a) -> (k', Maybe a')) -> Map k' a'
     mapMapMaybe map' f = Map.fromList . map (fmap fromJust) . filter (isJust . snd) . map f . Map.toList $ map'
 
-    funtionTypeExpandAndConvertToFgType
+    funtionTypeConvertToFgType
       :: (ModuleName, Name) -- for debugging purposes
-      -> Json.FunctionType Type
+      -> Json.FunctionType ty
       -> Maybe (Either TyConParseError (Json.FunctionType (FgType (FgTyCon T.Text))))
-    funtionTypeExpandAndConvertToFgType dbg funType = do
-      funTyExpanded <- traverse (toFgType pprFun . expandTypeSynonyms) funType
-      pure $ traverse (traverse (tyConToFgTyCon pprFun package dbg)) funTyExpanded
+    funtionTypeConvertToFgType dbg funType = do
+      let convert :: Type -> Maybe (Either TyConParseError (FgType (FgTyCon T.Text)))
+          convert = fmap (traverse (tyConToFgTyCon pprFun package dbg)) . toFgType pprFun
+      sequenceA <$> traverse tyToFgType funType
 
     fullyQualify', noQualify' :: Outputable a => a -> T.Text
     fullyQualify' = pprFun . fullyQualify
     noQualify' = pprFun . noQualify
 
-data TodoError
+data TodoError -- WIP
   = TodoError_Forall (Forall.ForallError T.Text)
   | TodoError_TyCon TyConParseError
       deriving (Eq, Show)

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -475,8 +475,8 @@ tyConAppToFgTypeTyCon
      -- ^ Second argument to 'TyConApp'
   -> Maybe (FgType (Either TyCon a))
 tyConAppToFgTypeTyCon recurse tyCon = \case
-  [] | isTupleTyCon tyCon -> do -- unit
-      pure FgType_Unit
+  [] | isTupleTyCon tyCon, Just boxity <- tupleBoxity tyCon -> do -- unit
+      pure $ FgType_Unit boxity
   (ty1:ty2:tyTail) | Just boxity <- tupleBoxity tyCon -> do -- tuple (of size >= 2)
       ty1' <- recurse ty1
       tyTail' <- mapM recurse (ty2 NE.:| tyTail)

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -144,10 +144,6 @@ getDefinitions pprFun pkg_nm = do
     Nothing -> fail "unknown package"
   liftIO $ IO.hPutStrLn IO.stderr $ "   getDefinitions " ++ pkg_nm
   mDefinitions <- reportUnitDecls pprFun unit_info
-  -- WIP: pretty-print polymorphic functions to stderr
-  forM_ mDefinitions $ \defs -> do
-    let blah = concat $ map (ppFunctionMap pprFun) (Map.elems defs)
-    void $ liftIO $ mapM (TIO.hPutStrLn IO.stderr) blah
   let f :: Map ModuleName FunctionMap
         -> Map ModuleName (Map Name (Either FgError Doodle.SomeFunction))
       f = fmap (fmap (fmap eitherToSomeFunction . runExcept))

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -316,8 +316,8 @@ parseType pprFun package dbg tyInit =
     goSimple ty =
       case splitFunTys ty of
         ([arg], res) -> do
-          arg' <- toFgType $ scaledThing arg
-          res' <- toFgType res
+          arg' <- toFgType pprFun $ scaledThing arg
+          res' <- toFgType pprFun res
           let eResult = do
                 arg'' <- traverse (tyConToFgTyCon pprFun package dbg) arg'
                 res'' <- traverse (tyConToFgTyCon pprFun package dbg) res'
@@ -390,8 +390,8 @@ declarationMapToJson pprFun dm =
       -> Json.FunctionType Type
       -> Maybe (Either TyConParseError (Json.TypeInfo (FgType (FgTyCon T.Text))))
     funtionTypeToTypeInfo dbg funType = do
-      funTyExpanded <- traverse (toFgType . expandTypeSynonyms) funType
-      funTy <- traverse toFgType funType
+      funTyExpanded <- traverse (toFgType pprFun . expandTypeSynonyms) funType
+      funTy <- traverse (toFgType pprFun) funType
       let funTypeInfo = Json.TypeInfo
             { Json.typeInfo_expanded = if funTyExpanded == funTy then Nothing else Just funTyExpanded
             , Json.typeInfo_unexpanded = funTy
@@ -482,7 +482,8 @@ noQualify =
 
 -- | Convert a 'TyConApp' to a 'FgType TyCon'
 tyConAppToFgTypeTyCon
-  :: (KindOrType -> Maybe (FgType (Either TyCon a)))
+  :: (SDoc -> T.Text)
+  -> (KindOrType -> Maybe (FgType (Either TyCon a)))
      -- ^ Recursive case
      --
      -- TODO: why 'Maybe' and 'Either'?
@@ -491,7 +492,7 @@ tyConAppToFgTypeTyCon
   -> [KindOrType]
      -- ^ Second argument to 'TyConApp'
   -> Maybe (FgType (Either TyCon a))
-tyConAppToFgTypeTyCon recurse tyCon = \case
+tyConAppToFgTypeTyCon pprFun recurse tyCon tyConArgList = case assertSaturated of
   [] | isTupleTyCon tyCon, Just boxity <- tupleBoxity tyCon -> do -- unit
       pure $ FgType_Unit boxity
   (ty1:ty2:tyTail) | Just boxity <- tupleBoxity tyCon -> do -- tuple (of size >= 2)
@@ -510,13 +511,21 @@ tyConAppToFgTypeTyCon recurse tyCon = \case
       | isBoxedTupleTyCon tyCon = Just Types.Boxed
       | otherwise = Nothing
 
+    assertSaturated =
+      if length tyConArgList == tyConArity tyCon
+        then tyConArgList
+        else error $ "BUG: unexpected unsaturated type constructor. TyCon: " <> T.unpack (pprFun (ppr tyCon)) <> ", Args: " <> T.unpack (pprFun (ppr tyConArgList))
+
 -- | Convert a 'Type' to a 'FgType'. Only 'TyConApp' is supported currently.
-toFgType :: Type -> Maybe (FgType TyCon)
-toFgType = \case
-  TyConApp tyCon tyConList ->
-    fmap (fromLeft (error "toFgType: impossible")) <$>
-      tyConAppToFgTypeTyCon (fmap (fmap Left) . toFgType) tyCon tyConList
-  _ -> Nothing
+toFgType :: (SDoc -> T.Text) -> Type -> Maybe (FgType TyCon)
+toFgType pprFun =
+  go
+  where
+    go = \case
+      TyConApp tyCon tyConList ->
+        fmap (fromLeft (error "toFgType: impossible")) <$>
+          tyConAppToFgTypeTyCon pprFun (fmap (fmap Left) . go) tyCon tyConList
+      _ -> Nothing
 
 toFgType'
   :: (SDoc -> T.Text)
@@ -526,8 +535,8 @@ toFgType' pprFun ty =
   go ty
   where
     go = \case
-      TyConApp tyCon tyConList -> -- WIP: ignore unless only Type kind(s) -- e.g. no Constraints
-        tyConAppToFgTypeTyCon go tyCon tyConList
+      TyConApp tyCon tyConList ->
+        tyConAppToFgTypeTyCon pprFun go tyCon tyConList
       TyVarTy tyVar ->
         pure $ FgType_TyConApp (Right tyVar) []
       appTy@AppTy{} -> do

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -153,50 +153,8 @@ ppFunctionMap pprFun fm = catMaybes $
       T.unwords
         [ pprFun (ppr name)
         , "::"
-        , prettyPrintFTFGeneric renderFgTyConUnqualified fun
+        , renderFunctionTypeForallGeneric id renderFgTyConUnqualified fun
         ]
-
-prettyPrintFunction
-  :: Either
-      (FunctionType (FgType (FgTyCon T.Text)))
-      (FunctionTypeForall T.Text T.Text)
-  -> T.Text
-prettyPrintFunction =
-  either prettyPrintFT prettyPrintFTF
-
-prettyPrintFT :: FunctionType (FgType (FgTyCon T.Text)) -> T.Text
-prettyPrintFT ft = T.unwords
-  [ renderFgType renderFgTyConQualified (functionType_arg ft)
-  , "->"
-  , renderFgType renderFgTyConQualified (functionType_ret ft)
-  ]
-
-prettyPrintFTF :: FunctionTypeForall T.Text T.Text -> T.Text
-prettyPrintFTF ftf = T.unwords
-  [ Forall.renderForall id $ ftf_forall ftf
-  , renderFgType' $ ftf_arg ftf
-  , "->"
-  , renderFgType' $ ftf_ret ftf
-  ]
-  where
-    renderFgType' :: FgType (Either (FgTyCon T.Text) (Forall.TyVar T.Text)) -> T.Text
-    renderFgType' =
-      renderFgType (either renderFgTyConQualifiedNoPackage Forall.getTyVar)
-
-prettyPrintFTFGeneric
-  :: (FgTyCon T.Text -> T.Text)
-  -> FunctionTypeForall T.Text T.Text
-  -> T.Text
-prettyPrintFTFGeneric renderFgTyCon ftf = T.unwords
-  [ Forall.renderForall id $ ftf_forall ftf
-  , renderFgType' $ ftf_arg ftf
-  , "->"
-  , renderFgType' $ ftf_ret ftf
-  ]
-  where
-    renderFgType' :: FgType (Either (FgTyCon T.Text) (Forall.TyVar T.Text)) -> T.Text
-    renderFgType' =
-      renderFgType (either renderFgTyCon Forall.getTyVar)
 
 type FunctionMap =
   Map

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -308,7 +308,7 @@ parseType pprFun package dbg tyInit =
                         in if ftfTxt /= ftfTxtGhc
                           then T.unpack ("DIFF: " <> nameTxt <> "\n      " <> ftfTxt <> "\n      " <> ftfTxtGhc <> "\n") `trace` ftf
                           else ftf
-                  pure $ (if doDebugPrintDiff then debugPrintDiff else id) $ FunctionTypeForall forall_ arg'' res''
+                  pure $ (if doDebugPrintDiff then debugPrintDiff else id) $ mkFunctionTypeForall forall_ arg'' res''
             pure $
               either
               throwError -- WIP: don't throw exception

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -492,29 +492,27 @@ tyConAppToFgTypeTyCon
   -> [KindOrType]
      -- ^ Second argument to 'TyConApp'
   -> Maybe (FgType (Either TyCon a))
-tyConAppToFgTypeTyCon pprFun recurse tyCon tyConArgList = case assertSaturated of
-  [] | isTupleTyCon tyCon, Just boxity <- tupleBoxity tyCon -> do -- unit
+tyConAppToFgTypeTyCon pprFun recurse tyCon = \case
+  [] | isTupleTyCon tyCon, Just boxity <- tupleBoxity -> do -- unit
       pure $ FgType_Unit boxity
-  (ty1:ty2:tyTail) | Just boxity <- tupleBoxity tyCon -> do -- tuple (of size >= 2)
-      ty1' <- recurse ty1
-      tyTail' <- mapM recurse (ty2 NE.:| tyTail)
-      pure $ FgType_Tuple boxity ty1' tyTail'
-  [ty1] | getUnique tyCon == listTyConKey -> do -- list
-    ty1' <- recurse ty1
-    pure $ FgType_List ty1'
+  args@(_:_:_) | Just boxity <- tupleBoxity -> do -- tuple (of size >= 2)
+      args' <- mapM recurse args
+      pure $ FgType_Tuple boxity (fromIntegral $ tyConArity tyCon) args'
+  mTy | getUnique tyCon == listTyConKey -> do -- list
+    case mTy of
+      [] -> pure $ FgType_List Nothing
+      [ty1] -> do
+        ty1' <- recurse ty1
+        pure $ FgType_List (Just ty1')
+      _ -> Nothing
   tyList -> do -- neither a tuple nor a list
     tyList' <- mapM recurse tyList
     pure $ FgType_TyConApp (Left tyCon) tyList'
   where
-    tupleBoxity tyCon
+    tupleBoxity
       | isUnboxedTupleTyCon tyCon = Just Types.Unboxed
       | isBoxedTupleTyCon tyCon = Just Types.Boxed
       | otherwise = Nothing
-
-    assertSaturated =
-      if length tyConArgList == tyConArity tyCon
-        then tyConArgList
-        else error $ "BUG: unexpected unsaturated type constructor. TyCon: " <> T.unpack (pprFun (ppr tyCon)) <> ", Args: " <> T.unpack (pprFun (ppr tyConArgList))
 
 -- | Convert a 'Type' to a 'FgType'. Only 'TyConApp' is supported currently.
 toFgType :: (SDoc -> T.Text) -> Type -> Maybe (FgType TyCon)

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -364,23 +364,22 @@ parseType pprFun package dbg tyInit = sequenceA $
 
 data DeclarationMap ty = DeclarationMap
   { declarationMap_package :: UnitId
-  , declarationMap_moduleDeclarations :: Map ModuleName (Map Name Doodle.SomeFunction)
+  , declarationMap_moduleDeclarations :: Map ModuleName (Map Name ty)
     -- ^ -- A map from a module name to the declarations in that module
   }
 
 declarationMapToJson
   :: forall ty.
      (SDoc -> T.Text)
-  -> (ty -> Maybe (Either TyConParseError (FgType (FgTyCon T.Text))))
-  -> DeclarationMap ty
+  -> DeclarationMap (Either FgError SomeFunction)
   -> Json.DeclarationMapJson T.Text
-declarationMapToJson pprFun tyToFgType dm =
+declarationMapToJson pprFun dm =
   let
     eitherMap :: Map T.Text (Map T.Text (Either FgError SomeFunction))
     eitherMap = mapMap (declarationMap_moduleDeclarations dm) $ \(modName, nameMap) ->
       ( fullyQualify' modName
-      , mapMapMaybe nameMap $ \(name, someFunction) ->
-          (noQualify' name, Just $ Right someFunction)
+      , mapMapMaybe nameMap $ \(name, either') -> — TODO: no Maybe
+          (noQualify' name, either')
       )
 
   in Json.DeclarationMapJson

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -133,11 +133,11 @@ getDefinitions pprFun pkg_nm = do
   unit_info <- case lookupUnitId unit_state unit_id of
     Just unit_info -> return unit_info
     Nothing -> fail "unknown package"
+  liftIO $ IO.hPutStrLn IO.stderr $ "getDefinitions " ++ pkg_nm
   mDefinitions <- reportUnitDecls pprFun unit_info
   forM_ mDefinitions $ \defs -> do
     let blah = concat $ map (ppFunctionMap pprFun) (Map.elems defs)
     void $ liftIO $ mapM (TIO.hPutStrLn IO.stderr) blah
-  liftIO $ IO.hPutStrLn IO.stderr $ "getDefinitions " ++ pkg_nm
   pure $ DeclarationMap unit_id <$> Nothing
 
 ppFunctionMap

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -57,6 +57,9 @@ import Data.Either (fromLeft, fromRight)
 import Data.Functor ((<&>), void)
 import qualified Data.Text.IO as TIO
 import qualified GHC.Driver.Session
+import qualified Types.Doodle as Doodle
+import Data.Void (Void, absurd)
+import Control.Monad.Trans.Except (ExceptT, throwE, except, withExcept, withExceptT, Except)
 
 -- | The output printed to stdout can be parsed as JSON into this data type.
 --
@@ -74,16 +77,16 @@ main = do
       runGhc' ghcLibDir (getPprFun first_package_name) >>= either (fail . show) (\pprFun -> pure $ (pprFun, ghcLibDir, pkg_names))
   lst <- forM pkg_names $ \pkg_nm -> do
     unsafeInterleaveIO $ runGhc' ghcLibDir (getDefinitions (pprFun . pprSuppressVarKinds) pkg_nm) >>= logErrors
-  let declarationMapJsonList = map (declarationMapToJson (pprFun . pprSuppressVarKinds) (Just . Right)) (catMaybes lst)
+  let declarationMapJsonList = map (declarationMapToJson (pprFun . pprSuppressVarKinds) absurd) (catMaybes lst)
   forM_ declarationMapJsonList $ \declarationMapJson -> do
     let errors = Map.assocs $ Map.assocs <$> Json.moduleDeclarations_mapFail (Json.declarationMapJson_moduleDeclarations declarationMapJson)
     forM_ errors $ \(modName, pkgErrs) ->
       forM_ pkgErrs $ \(defnName, err) ->
         logError $ T.unpack $ T.unwords
           [ "WARNING:"
-          , T.pack $ show (tyConParseErrorInput err)
+          -- , T.pack $ show (tyConParseErrorInput err) -- WIP
           , "failed to parse" <> "."
-          , renderTyConParseError err
+          , renderFgError err
           ]
   Json.streamPrintJsonList (declarationMapJsonList :: StdoutJsonFormat)
   where
@@ -137,7 +140,7 @@ getPprFun pkg_nm = do
           blahTodo sDocContext' = sDocContext'{sdocSuppressVarKinds = True, sdocPrintExplicitKinds = False, sdocStarIsType = True}
       in renderWithContext (blahTodo sDocContext) doc'
 
-getDefinitions :: (SDoc -> T.Text) -> String -> Ghc (Maybe (DeclarationMap (FgType (FgTyCon T.Text))))
+getDefinitions :: (SDoc -> T.Text) -> String -> Ghc (Maybe (DeclarationMap Void))
 getDefinitions pprFun pkg_nm = do
   _ <- setDFlags pkg_nm
   unit_state <- hsc_units <$> getSession
@@ -149,11 +152,13 @@ getDefinitions pprFun pkg_nm = do
     Nothing -> fail "unknown package"
   liftIO $ IO.hPutStrLn IO.stderr $ "   getDefinitions " ++ pkg_nm
   mDefinitions <- reportUnitDecls pprFun unit_info
+  -- WIP: pretty-print polymorphic functions to stderr
   forM_ mDefinitions $ \defs -> do
     let blah = concat $ map (ppFunctionMap pprFun) (Map.elems defs)
     void $ liftIO $ mapM (TIO.hPutStrLn IO.stderr) blah
-  let f :: Map ModuleName FunctionMap -> Map ModuleName (Map Name (Json.FunctionType (FgType (FgTyCon T.Text))))
-      f = fmap $ Map.mapMaybe $ either Just (const Nothing)
+  let f :: Map ModuleName FunctionMap
+        -> Map ModuleName (Map Name Doodle.SomeFunction)
+      f = fmap (fmap eitherToSomeFunction)
   pure $ DeclarationMap unit_id . f <$> mDefinitions
 
 ppFunctionMap
@@ -174,17 +179,17 @@ ppFunctionMap pprFun fm = catMaybes $
 
 prettyPrintFunction
   :: Either
-      (Json.FunctionType (FgType (FgTyCon T.Text)))
+      (FunctionType (FgType (FgTyCon T.Text)))
       (FunctionTypeForall T.Text T.Text)
   -> T.Text
 prettyPrintFunction =
   either prettyPrintFT prettyPrintFTF
 
-prettyPrintFT :: Json.FunctionType (FgType (FgTyCon T.Text)) -> T.Text
+prettyPrintFT :: FunctionType (FgType (FgTyCon T.Text)) -> T.Text
 prettyPrintFT ft = T.unwords
-  [ renderFgType renderFgTyConQualified (Json.functionType_arg ft)
+  [ renderFgType renderFgTyConQualified (functionType_arg ft)
   , "->"
-  , renderFgType renderFgTyConQualified (Json.functionType_ret ft)
+  , renderFgType renderFgTyConQualified (functionType_ret ft)
   ]
 
 prettyPrintFTF :: FunctionTypeForall T.Text T.Text -> T.Text
@@ -217,9 +222,12 @@ prettyPrintFTFGeneric renderFgTyCon ftf = T.unwords
 type FunctionMap =
   Map
     Name
-    (Either
-      (Json.FunctionType (FgType (FgTyCon T.Text)))
-      (FunctionTypeForall T.Text T.Text)
+    (Except
+      FgError
+      (Either
+        (FunctionType (FgType (FgTyCon T.Text)))
+        (FunctionTypeForall T.Text T.Text)
+      )
     )
 
 reportUnitDecls :: (SDoc -> T.Text) -> UnitInfo -> Ghc (Maybe (Map ModuleName FunctionMap))
@@ -273,81 +281,82 @@ reportModuleDecls pprFun unit_id modl_nm = do
 
 -- TODO: postpone conversion of GHC 'Type' to 'FgType'? Or just use 'funtionTypeExpandAndConvertToFgType' in here?
 parseType
-  :: (SDoc -> T.Text)
+  :: forall m.
+     (SDoc -> T.Text)
   -> UnitId
   -> (ModuleName, Name)
   -> Type
-  -> Maybe -- a 'Just' if this type is supported
-      (Either
-        (Json.FunctionType (FgType (FgTyCon T.Text))) -- only concrete types
-        (FunctionTypeForall T.Text T.Text) -- both concrete types and type variables
+  -> Maybe
+      (ExceptT
+        FgError
+        m
+        (Either
+            (FunctionType (FgType (FgTyCon T.Text))) -- only concrete types
+            (FunctionTypeForall T.Text T.Text) -- both concrete types and type variables
+        )
       )
-parseType pprFun package dbg tyInit =
+    -- ^ 'Nothing': type not supported
+    --   'Just': type supported
+parseType pprFun package dbg tyInit = sequenceA $
   case splitFunTys tyInit of
     ([], res) ->
       case res of
-        ForAllTy bndr ty' | isTypeKind bndr ->
-          Right <$> goForall (parseForall Nothing bndr) ty'
-        _ -> Nothing
+        ForAllTy bndr ty' | isTypeKind bndr -> do
+          forall_ <- parseForall Nothing bndr
+          fmap Right <$> goForall forall_ ty'
+        _ -> pure Nothing
     ([_], _) ->
-      Left <$> goSimple tyInit
-    _ -> Nothing
+      fmap Left <$> goSimple tyInit
+    _ -> pure Nothing
   where
+    goForall
+      :: Forall.Forall T.Text
+      -> Type
+      -> ExceptT
+          FgError
+          m
+          (Maybe (FunctionTypeForall T.Text T.Text))
     goForall forall_ ty =
       case splitFunTys ty of
         ([], res) ->
           case res of
             ForAllTy bndr ty' | isTypeKind bndr -> do
-              goForall (parseForall (Just forall_) bndr) ty'
-            _ -> Nothing
+              forall_' <- parseForall (Just forall_) bndr
+              goForall forall_' ty'
+            _ -> pure Nothing
         ([arg], res) | not (returnsConstraintKind $ GHC.Core.Type.typeKind (scaledThing arg)) -> do
-            arg' <- toFgType' pprFun $ scaledThing arg
-            res' <- toFgType' pprFun res
-            let eResult = do
-                  arg'' <- traverse (tyConOrTyVarTODO pprFun package dbg forall_) arg'
-                  res'' <- traverse (tyConOrTyVarTODO pprFun package dbg forall_) res'
-                  let debugPrintDiff ftf =
-                        let ftfTxt = prettyPrintFTFGeneric renderFgTyConQualified ftf
-                            ftfTxtGhc = pprFun $ fullyQualify $ ppr tyInit
-                            nameTxt = pprFun $ ppr (snd dbg)
-                        -- TODO: add this to a test suite!!
-                        in if ftfTxt /= ftfTxtGhc
-                          then T.unpack ("DIFF: " <> nameTxt <> "\n      " <> ftfTxt <> "\n      " <> ftfTxtGhc <> "\n") `trace` ftf
-                          else ftf
-                  pure $ (if doDebugPrintDiff then debugPrintDiff else id) $ mkFunctionTypeForall forall_ arg'' res''
-            pure $
-              either
-              throwError -- WIP: don't throw exception
-              id
-              eResult
-        (_, _) -> Nothing
-
-    doDebugPrintDiff = True
+            let mArgRes = do
+                  arg' <- toFgType' pprFun $ scaledThing arg
+                  res' <- toFgType' pprFun res
+                  Just (arg', res')
+            case mArgRes of
+              Just (arg', res') -> do
+                arg'' <- except $ traverse (tyConOrTyVarTODO pprFun package dbg forall_) arg'
+                res'' <- except $ traverse (tyConOrTyVarTODO pprFun package dbg forall_) res'
+                pure $ Just $ mkFunctionTypeForall forall_ arg'' res''
+              Nothing -> pure Nothing
+        (_, _) -> pure Nothing
 
     goSimple ty =
       case splitFunTys ty of
         ([arg], res) -> do
-          arg' <- toFgType pprFun $ scaledThing arg
-          res' <- toFgType pprFun res
-          let eResult = do
-                arg'' <- traverse (tyConToFgTyCon pprFun package dbg) arg'
-                res'' <- traverse (tyConToFgTyCon pprFun package dbg) res'
-                pure $ Json.FunctionType arg'' res''
-          pure $
-            either
-            throwError -- WIP: don't throw exception
-            id
-            eResult
-        _ -> Nothing
+          let mArgRes = do
+                arg' <- toFgType pprFun $ scaledThing arg
+                res' <- toFgType pprFun res
+                Just (arg', res')
+          case mArgRes of
+            Just (arg', res') -> withExceptT FgError_TyCon $ do
+              arg'' <- except $ traverse (tyConToFgTyCon pprFun package dbg) arg'
+              res'' <- except $ traverse (tyConToFgTyCon pprFun package dbg) res'
+              pure $ Just $ FunctionType arg'' res''
+            Nothing -> pure Nothing
+        _ -> pure Nothing
 
     parseForall mForall (Bndr tyCoVar _) =
       let mkForall = maybe (Right . Forall.singleton) (\forall' -> (`Forall.appendTyVar` forall')) mForall
           tyVarName = pprFun (ppr tyCoVar) -- WIP: correct?
           eForall = mkForall tyVarName
-      in either throwError id eForall -- WIP: don't throw exception
-
-    throwError showable =
-      error $ show showable ++ " -- " ++ T.unpack (pprFun $ ppr tyInit)
+      in either (throwE . FgError_Forall) pure eForall -- WIP: don't throw exception
 
     -- is kind *
     isTypeKind (Bndr tyVar _) =
@@ -355,7 +364,7 @@ parseType pprFun package dbg tyInit =
 
 data DeclarationMap ty = DeclarationMap
   { declarationMap_package :: UnitId
-  , declarationMap_moduleDeclarations :: Map ModuleName (Map Name (Json.FunctionType ty))
+  , declarationMap_moduleDeclarations :: Map ModuleName (Map Name Doodle.SomeFunction)
     -- ^ -- A map from a module name to the declarations in that module
   }
 
@@ -367,11 +376,11 @@ declarationMapToJson
   -> Json.DeclarationMapJson T.Text
 declarationMapToJson pprFun tyToFgType dm =
   let
-    eitherMap :: Map T.Text (Map T.Text (Either TyConParseError (Json.FunctionType (FgType (FgTyCon T.Text)))))
+    eitherMap :: Map T.Text (Map T.Text (Either FgError SomeFunction))
     eitherMap = mapMap (declarationMap_moduleDeclarations dm) $ \(modName, nameMap) ->
       ( fullyQualify' modName
-      , mapMapMaybe nameMap $ \(name, functionType) ->
-          (noQualify' name, funtionTypeConvertToFgType (modName, name) functionType)
+      , mapMapMaybe nameMap $ \(name, someFunction) ->
+          (noQualify' name, Just $ Right someFunction)
       )
 
   in Json.DeclarationMapJson
@@ -398,23 +407,9 @@ declarationMapToJson pprFun tyToFgType dm =
     mapMapMaybe :: Ord k' => Map k a -> ((k, a) -> (k', Maybe a')) -> Map k' a'
     mapMapMaybe map' f = Map.fromList . map (fmap fromJust) . filter (isJust . snd) . map f . Map.toList $ map'
 
-    funtionTypeConvertToFgType
-      :: (ModuleName, Name) -- for debugging purposes
-      -> Json.FunctionType ty
-      -> Maybe (Either TyConParseError (Json.FunctionType (FgType (FgTyCon T.Text))))
-    funtionTypeConvertToFgType dbg funType = do
-      let convert :: Type -> Maybe (Either TyConParseError (FgType (FgTyCon T.Text)))
-          convert = fmap (traverse (tyConToFgTyCon pprFun package dbg)) . toFgType pprFun
-      sequenceA <$> traverse tyToFgType funType
-
     fullyQualify', noQualify' :: Outputable a => a -> T.Text
     fullyQualify' = pprFun . fullyQualify
     noQualify' = pprFun . noQualify
-
-data TodoError -- WIP
-  = TodoError_Forall (Forall.ForallError T.Text)
-  | TodoError_TyCon TyConParseError
-      deriving (Eq, Show)
 
 tyConOrTyVarTODO
   :: (SDoc -> T.Text)
@@ -422,11 +417,11 @@ tyConOrTyVarTODO
   -> (ModuleName, Name) -- for debugging purposes
   -> Forall.Forall T.Text
   -> Either TyCon TyVar
-  -> Either TodoError (Either (FgTyCon T.Text) (Forall.TyVar T.Text))
+  -> Either FgError (Either (FgTyCon T.Text) (Forall.TyVar T.Text))
 tyConOrTyVarTODO pprFun package dbg forall_ =
   either
-    (fmap Left . first TodoError_TyCon . tyConToFgTyCon pprFun package dbg)
-    (fmap Right . first TodoError_Forall . tyVarToTODO pprFun package dbg forall_)
+    (fmap Left . first FgError_TyCon . tyConToFgTyCon pprFun package dbg)
+    (fmap Right . first FgError_Forall . tyVarToTODO pprFun package dbg forall_)
 
 tyVarToTODO
   :: (SDoc -> T.Text)

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -59,13 +59,13 @@ import qualified GHC.Driver.Session
 
 main :: IO ()
 main = do
-  pkg_names <- getArgs
+  args <- getArgs
   let runGhc' :: FilePath -> Ghc a -> IO (Either Control.Monad.Catch.SomeException a)
       runGhc' libdir action = reallyCatch $ runGhc (Just libdir) action
-  (pprFun, ghcLibDir) <- case pkg_names of
+  (pprFun, ghcLibDir, pkg_names) <- case args of
     [] -> Exit.die "Missing argument(s): one or more packages"
-    ghcLibDir : (first_package_name : _) ->
-      runGhc' ghcLibDir (getPprFun first_package_name) >>= either (fail . show) (\lol -> pure $ (lol, ghcLibDir))
+    ghcLibDir : pkg_names@(first_package_name : _) ->
+      runGhc' ghcLibDir (getPprFun first_package_name) >>= either (fail . show) (\pprFun -> pure $ (pprFun, ghcLibDir, pkg_names))
   lst <- forM pkg_names $ \pkg_nm -> do
     unsafeInterleaveIO $ runGhc' ghcLibDir (getDefinitions (pprFun . pprSuppressVarKinds) pkg_nm) >>= logErrors
   let declarationMapJsonList = map (declarationMapToJson (pprFun . pprSuppressVarKinds)) (catMaybes lst)
@@ -141,7 +141,7 @@ getDefinitions pprFun pkg_nm = do
   unit_info <- case lookupUnitId unit_state unit_id of
     Just unit_info -> return unit_info
     Nothing -> fail "unknown package"
-  liftIO $ IO.hPutStrLn IO.stderr $ "getDefinitions " ++ pkg_nm
+  liftIO $ IO.hPutStrLn IO.stderr $ "   getDefinitions " ++ pkg_nm
   mDefinitions <- reportUnitDecls pprFun unit_info
   forM_ mDefinitions $ \defs -> do
     let blah = concat $ map (ppFunctionMap pprFun) (Map.elems defs)
@@ -157,12 +157,12 @@ ppFunctionMap pprFun fm = catMaybes $ -- WIP: ignore non-forall functions for no
   Map.toList fm <&> \(name, fun) ->
     either (const Nothing) (ppTodo name) fun
   where
-    ppTodo name !fun = Nothing --  Just $
-      -- T.unwords
-      --   [ pprFun (ppr name)
-      --   , "::"
-      --   , prettyPrintFTF fun
-      --   ]
+    ppTodo name !fun = Just $
+      T.unwords
+        [ pprFun (ppr name)
+        , "::"
+        , prettyPrintFTFGeneric renderFgTyConUnqualified fun
+        ]
 
 prettyPrintFunction
   :: Either
@@ -190,6 +190,21 @@ prettyPrintFTF ftf = T.unwords
     renderFgType' :: FgType (Either (FgTyCon T.Text) (Forall.TyVar T.Text)) -> T.Text
     renderFgType' =
       renderFgType (either renderFgTyConQualifiedNoPackage Forall.getTyVar)
+
+prettyPrintFTFGeneric
+  :: (FgTyCon T.Text -> T.Text)
+  -> FunctionTypeForall T.Text T.Text
+  -> T.Text
+prettyPrintFTFGeneric renderFgTyCon ftf = T.unwords
+  [ Forall.renderForall id $ ftf_forall ftf
+  , renderFgType' $ ftf_arg ftf
+  , "->"
+  , renderFgType' $ ftf_ret ftf
+  ]
+  where
+    renderFgType' :: FgType (Either (FgTyCon T.Text) (Forall.TyVar T.Text)) -> T.Text
+    renderFgType' =
+      renderFgType (either renderFgTyCon Forall.getTyVar)
 
 type FunctionMap =
   Map
@@ -281,10 +296,12 @@ parseType pprFun package dbg tyInit =
                   arg'' <- traverse (tyConOrTyVarTODO pprFun package dbg forall_) arg'
                   res'' <- traverse (tyConOrTyVarTODO pprFun package dbg forall_) res'
                   let debugPrintDiff ftf =
-                        let ftfTxt = prettyPrintFTF ftf
-                            ftfTxtGhc = pprFun (ppr tyInit)
+                        let ftfTxt = prettyPrintFTFGeneric renderFgTyConQualified ftf
+                            ftfTxtGhc = pprFun $ fullyQualify $ ppr tyInit
+                            nameTxt = pprFun $ ppr (snd dbg)
+                        -- TODO: add this to a test suite!!
                         in if ftfTxt /= ftfTxtGhc
-                          then T.unpack ("DIFF: " <> ftfTxt <> "\n      " <> ftfTxtGhc <> "\n") `trace` ftf
+                          then T.unpack ("DIFF: " <> nameTxt <> "\n      " <> ftfTxt <> "\n      " <> ftfTxtGhc <> "\n") `trace` ftf
                           else ftf
                   pure $ (if doDebugPrintDiff then debugPrintDiff else id) $ FunctionTypeForall forall_ arg'' res''
             pure $

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -144,12 +144,16 @@ ppFunctionMap
   :: (SDoc -> T.Text)
   -> FunctionMap
   -> [T.Text]
-ppFunctionMap pprFun fm =
-  Map.toList fm <&> \(name, fun) -> T.unwords
-    [ pprFun (ppr name)
-    , "::"
-    , prettyPrintFunction fun
-    ]
+ppFunctionMap pprFun fm = catMaybes $ -- WIP: ignore non-forall functions for now
+  Map.toList fm <&> \(name, fun) ->
+    either (const Nothing) (ppTodo name) fun
+  where
+    ppTodo name fun = Just $
+      T.unwords
+        [ pprFun (ppr name)
+        , "::"
+        , prettyPrintFTF fun
+        ]
 
 prettyPrintFunction
   :: Either
@@ -263,7 +267,7 @@ parseType pprFun package dbg tyInit =
           case res of
             ForAllTy bndr ty' -> do
               let forall' = parseForall (Just forall_) bndr
-              goForall (parseForall (Just forall') bndr) ty'
+              goForall forall' ty'
             _ -> Nothing
         ([arg], res) -> do
             arg' <- toFgType' pprFun $ scaledThing arg
@@ -274,7 +278,7 @@ parseType pprFun package dbg tyInit =
                   pure $ FunctionTypeForall forall_ arg'' res''
             pure $
               either
-              (error . show) -- WIP: don't throw exception
+              throwError -- WIP: don't throw exception
               id
               eResult
         (_, _) -> Nothing
@@ -290,7 +294,7 @@ parseType pprFun package dbg tyInit =
                 pure $ Json.FunctionType arg'' res''
           pure $
             either
-            (error . show) -- WIP: don't throw exception
+            throwError -- WIP: don't throw exception
             id
             eResult
         _ -> Nothing
@@ -299,7 +303,10 @@ parseType pprFun package dbg tyInit =
       let mkForall = maybe (Right . Forall.singleton) (\forall' -> (`Forall.appendTyVar` forall')) mForall
           tyVarName = pprFun (ppr tyCoVar) -- WIP: correct?
           eForall = mkForall tyVarName
-      in either (error . show) id eForall -- WIP: don't throw exception
+      in either throwError id eForall -- WIP: don't throw exception
+
+    throwError showable =
+      error $ show showable ++ " -- " ++ T.unpack (pprFun $ ppr tyInit)
 
 showType :: Type -> String
 showType = \case
@@ -487,7 +494,7 @@ toFgType = \case
 toFgType'
   :: (SDoc -> T.Text)
   -> Type
-  -> Maybe (FgType (Either TyCon (TyVarApp TyCon TyVar)))
+  -> Maybe (FgType (Either TyCon TyVar))
 toFgType' pprFun ty =
   go ty
   where
@@ -495,53 +502,31 @@ toFgType' pprFun ty =
       TyConApp tyCon tyConList ->
         tyConAppToFgTypeTyCon go tyCon tyConList
       TyVarTy tyVar ->
-        pure $ FgType_TyConApp (Right $ TyVar tyVar) []
-      appTy@(AppTy fun arg) -> do
-        fun' <- go fun
-        arg' <- go arg
-        case fun' of
-          FgType_TyConApp (Right tyVar) _ -> do
-            pure $ FgType_TyConApp (Right $ TyVarApp tyVar arg') []
-          _ ->
-            -- 'TyConApp' is not allowed as first argument to 'AppTy'.
-            -- TODO: why is 'FgType_TyConApp (Right tyVar)' not a TyConApp and everything else is?
-            -- See docs: https://hackage.haskell.org/package/ghc-9.6.1/docs/GHC-Core-TyCo-Rep.html#v:AppTy
-            error $ unwords
-              [ "Unexpected TyConApp as first argument to AppTy:"
-              , (T.unpack . pprFun . ppr $ appTy) <> "."
-              , "Outer type:"
-              , T.unpack . pprFun . ppr $ ty
-              ]
+        pure $ FgType_TyConApp (Right tyVar) []
+      appTy@AppTy{} -> do
+        let goAppTy
+              :: [FgType (Either TyCon TyVar)] -- argument accumulator
+              -> Type -- first argument to 'AppTy'
+              -> Maybe (TyVar, [FgType (Either TyCon TyVar)]) -- ("function" type variable, arguments)
+            goAppTy acc = \case
+              TyVarTy tyVar -> Just (tyVar, acc)
+              AppTy fun2 arg2 -> do
+                arg2' <- go arg2
+                goAppTy (arg2' : acc) fun2
+              TyConApp{} ->
+                -- 'TyConApp' is not allowed as first argument to 'AppTy'.
+                -- TODO: why is 'FgType_TyConApp (Right tyVar)' not a TyConApp and everything else is?
+                -- See docs: https://hackage.haskell.org/package/ghc-9.6.1/docs/GHC-Core-TyCo-Rep.html#v:AppTy
+                error $ unwords
+                  [ "Unexpected TyConApp as first argument to AppTy:"
+                  , (T.unpack . pprFun . ppr $ appTy) <> "."
+                  , "Outer type:"
+                  , T.unpack . pprFun . ppr $ ty
+                  ]
+              _ -> Nothing
+        (tyVar, args) <- goAppTy [] appTy
+        pure $ FgType_TyConApp (Right tyVar) args
       _ -> Nothing
-
-data TyVarApp tyCon tyVar
-  = TyVar tyVar
-  | TyVarApp (TyVarApp tyCon tyVar) (FgType (Either tyCon (TyVarApp tyCon tyVar)))
-
--- 1. TyCon TyCon        : TyConApp TyCon [TyConApp TyCon []]
--- 2. TyCon TyVar        : TyConApp TyCon [TyConApp TyVar []]
--- 3. TyVar TyCon        : TyConApp TyVar [TyConApp TyCon []]
--- 4. TyVar TyVar        : TyConApp TyVar [TyConApp TyVar []]
--- 4. (TyVar TyVar) TyVar:
-blah :: forall tycon. tycon -> FgType (FgType tycon)
-blah tyVar =
-  let test :: FgType tycon
-      test = FgType_TyConApp tyVar []
-  in FgType_TyConApp
-    (FgType_TyConApp tyVar [test])
-    []
-
--- Rewrite: 'App (App (Var a) (Var b)) (Var c)` to 'TyConApp (Var a) [(Var b) (Var c)]
---    ->
-f :: (f a b) c -> b
-f = undefined
-
-f'' :: f (a b) -> b
-f'' = undefined
-
-
-f' :: (Either a) b -> b
-f' = undefined
 
 parsePackageFromUnitId
   :: (SDoc -> T.Text)
@@ -551,7 +536,3 @@ parsePackageFromUnitId pprFun unitId =
   either (error . ("BUG: parsePackageFromUnitId: " <>)) id (parsePackageWithVersion $ fullyQualify' unitId)
   where
     fullyQualify' = pprFun . fullyQualify
-
-{-# WARNING todo "Unfinished TODO" #-}
-todo :: a
-todo = error "TODO"

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -314,17 +314,6 @@ parseType pprFun package dbg tyInit =
     throwError showable =
       error $ show showable ++ " -- " ++ T.unpack (pprFun $ ppr tyInit)
 
-showType :: Type -> String
-showType = \case
-  TyVarTy{} -> "TyVarTy"
-  AppTy {} -> "AppTy"
-  TyConApp {} -> "TyConApp"
-  ForAllTy {} -> "ForAllTy"
-  FunTy  {} -> "FunTy"
-  LitTy {} -> "LitTy"
-  CastTy{} -> "CastTy"
-  CoercionTy{} -> "CoercionTy"
-
 data DeclarationMap = DeclarationMap
   { declarationMap_package :: UnitId
   , declarationMap_moduleDeclarations :: Map ModuleName (Map Name (Json.FunctionType Type))
@@ -515,9 +504,9 @@ toFgType' pprFun ty =
         let goAppTy
               :: [FgType (Either TyCon TyVar)] -- "argument" accumulator. accumulates the second argument to "AppTy" (ie. the "argument" type).
               -> Type -- the first argument to 'AppTy' (ie. the "function" type variable)
-              -> Maybe (TyVar, [FgType (Either TyCon TyVar)]) -- ("function" type variable, argument type variables/constructors)
+              -> Maybe (FgType (Either TyCon TyVar))
             goAppTy acc = \case
-              TyVarTy tyVar -> Just (tyVar, acc)
+              tyVarTy@TyVarTy{} -> go tyVarTy
               AppTy fun2 arg2 -> do
                 arg2' <- go arg2
                 goAppTy (arg2' : acc) fun2
@@ -531,8 +520,7 @@ toFgType' pprFun ty =
                   , T.unpack . pprFun . ppr $ ty
                   ]
               _ -> Nothing
-        (tyVar, args) <- goAppTy [] appTy
-        pure $ FgType_TyConApp (Right tyVar) args
+        goAppTy [] appTy
       _ -> Nothing
 
 parsePackageFromUnitId

--- a/dump-decls-exe/exe/Exe.hs
+++ b/dump-decls-exe/exe/Exe.hs
@@ -146,14 +146,16 @@ getDefinitions pprFun pkg_nm = do
   forM_ mDefinitions $ \defs -> do
     let blah = concat $ map (ppFunctionMap pprFun) (Map.elems defs)
     void $ liftIO $ mapM (TIO.hPutStrLn IO.stderr) blah
+  let f :: Map ModuleName FunctionMap -> Map ModuleName (Map Name (Json.FunctionType Type))
+      f = fmap $ (Map.mapMaybe $ either Just (const Nothing))
   pure $ DeclarationMap unit_id <$> Nothing
+  --
 
 ppFunctionMap
   :: (SDoc -> T.Text)
   -> FunctionMap
   -> [T.Text]
-ppFunctionMap pprFun fm = catMaybes $ -- WIP: ignore non-forall functions for now -- WIP: ignore non-forall functions for now
-   -- WIP: ignore non-forall functions for now
+ppFunctionMap pprFun fm = catMaybes $ -- WIP: ignore non-forall functions for now
   Map.toList fm <&> \(name, fun) ->
     either (const Nothing) (ppTodo name) fun
   where
@@ -261,6 +263,7 @@ reportModuleDecls pprFun unit_id modl_nm = do
             ]
     pure $ Map.fromList contents
 
+-- TODO: postpone conversion of GHC 'Type' to 'FgType'? Or just use 'funtionTypeExpandAndConvertToFgType' in here?
 parseType
   :: (SDoc -> T.Text)
   -> UnitId
@@ -354,11 +357,11 @@ declarationMapToJson
   -> Json.DeclarationMapJson T.Text
 declarationMapToJson pprFun dm =
   let
-    eitherMap :: Map T.Text (Map T.Text (Either TyConParseError (Json.TypeInfo (FgType (FgTyCon T.Text)))))
+    eitherMap :: Map T.Text (Map T.Text (Either TyConParseError (Json.FunctionType (FgType (FgTyCon T.Text)))))
     eitherMap = mapMap (declarationMap_moduleDeclarations dm) $ \(modName, nameMap) ->
       ( fullyQualify' modName
       , mapMapMaybe nameMap $ \(name, functionType) ->
-          (noQualify' name, funtionTypeToTypeInfo (modName, name) functionType)
+          (noQualify' name, funtionTypeExpandAndConvertToFgType (modName, name) functionType)
       )
 
   in Json.DeclarationMapJson
@@ -385,18 +388,13 @@ declarationMapToJson pprFun dm =
     mapMapMaybe :: Ord k' => Map k a -> ((k, a) -> (k', Maybe a')) -> Map k' a'
     mapMapMaybe map' f = Map.fromList . map (fmap fromJust) . filter (isJust . snd) . map f . Map.toList $ map'
 
-    funtionTypeToTypeInfo
+    funtionTypeExpandAndConvertToFgType
       :: (ModuleName, Name) -- for debugging purposes
       -> Json.FunctionType Type
-      -> Maybe (Either TyConParseError (Json.TypeInfo (FgType (FgTyCon T.Text))))
-    funtionTypeToTypeInfo dbg funType = do
+      -> Maybe (Either TyConParseError (Json.FunctionType (FgType (FgTyCon T.Text))))
+    funtionTypeExpandAndConvertToFgType dbg funType = do
       funTyExpanded <- traverse (toFgType pprFun . expandTypeSynonyms) funType
-      funTy <- traverse (toFgType pprFun) funType
-      let funTypeInfo = Json.TypeInfo
-            { Json.typeInfo_expanded = if funTyExpanded == funTy then Nothing else Just funTyExpanded
-            , Json.typeInfo_unexpanded = funTy
-            }
-      pure $ traverse (traverse (tyConToFgTyCon pprFun package dbg)) funTypeInfo
+      pure $ traverse (traverse (tyConToFgTyCon pprFun package dbg)) funTyExpanded
 
     fullyQualify', noQualify' :: Outputable a => a -> T.Text
     fullyQualify' = pprFun . fullyQualify

--- a/dump-decls-exe/test/Spec.hs
+++ b/dump-decls-exe/test/Spec.hs
@@ -43,9 +43,9 @@ specPutStrLn =
     tyConString = parsePprTyCon "base-4.18.0.0:GHC.Base.String"
     tyConAppIOUnit = Types.FgType_TyConApp tyConIO [Types.FgType_Unit Types.Boxed] -- IO ()
 
-    ftPutStrLn = Json.FunctionType
-            { Json.functionType_arg = Types.FgType_List $ Just $ Types.FgType_TyConApp tyConChar [] -- [Char]
-            , Json.functionType_ret = tyConAppIOUnit
+    ftPutStrLn = Types.FunctionType
+            { Types.functionType_arg = Types.FgType_List $ Just $ Types.FgType_TyConApp tyConChar [] -- [Char]
+            , Types.functionType_ret = tyConAppIOUnit
             }
         -- , Json.typeInfo_unexpanded = Json.FunctionType
         --     { Json.functionType_arg = Types.FgType_TyConApp tyConString [] -- String
@@ -63,9 +63,9 @@ specUnsnoc =
     fgTypeChar = Types.FgType_TyConApp tyConChar []
     tyConMaybe = parsePprTyCon "base-4.18.0.0:GHC.Maybe.Maybe"
 
-    funtionType = Json.FunctionType
-      { Json.functionType_arg = fgTypeText
-      , Json.functionType_ret = Types.FgType_TyConApp
+    funtionType = Types.FunctionType
+      { Types.functionType_arg = fgTypeText
+      , Types.functionType_ret = Types.FgType_TyConApp
           tyConMaybe
           [Types.FgType_Tuple Types.Boxed 2 [fgTypeText, fgTypeChar]]
       }
@@ -74,7 +74,7 @@ mkSpec
   :: T.Text -- Package with version (e.g. @base-4.18.0.0@)
   -> T.Text -- Module name (e.g. @System.IO@)
   -> T.Text -- Definition name (e.g. @putStrLn@)
-  -> Json.FunctionType (Types.FgType (Types.FgTyCon T.Text))
+  -> Types.FunctionType (Types.FgType (Types.FgTyCon T.Text))
   -> [Json.DeclarationMapJson T.Text]
   -> Test.Hspec.Spec
 mkSpec pkgName modName defnName expected declarationMapJson =
@@ -105,7 +105,7 @@ tyConChar = parsePprTyCon "ghc-prim-0.10.0:GHC.Types.Char"
 newtype IgnorePackageVersion a = IgnorePackageVersion a
   deriving (Show)
 
-instance Eq (IgnorePackageVersion (Json.FunctionType (Types.FgType (Types.FgTyCon T.Text)))) where
+instance Eq (IgnorePackageVersion (Types.FunctionType (Types.FgType (Types.FgTyCon T.Text)))) where
   IgnorePackageVersion ti1 == IgnorePackageVersion ti2 =
     let strikePkgVersionFgPackage pkg = pkg { Types.fgPackageVersion = "" }
 

--- a/dump-decls-exe/test/Spec.hs
+++ b/dump-decls-exe/test/Spec.hs
@@ -15,6 +15,8 @@ import qualified Test.Hspec
 import Test.Hspec.Expectations.Pretty (shouldNotBe, shouldBe)
 import Data.Maybe (fromJust)
 import qualified Data.Map as Map
+import qualified Types.Doodle
+import Data.Bifunctor (first)
 
 main :: IO ()
 main = do
@@ -30,7 +32,7 @@ main = do
 
 spec :: [Json.DeclarationMapJson T.Text] -> Test.Hspec.Spec
 spec declarationMapJson =
-  Test.Hspec.describe "Expected TypeInfo" $ do
+  Test.Hspec.describe "Expected FunctionType" $ do
     specPutStrLn declarationMapJson
     specUnsnoc declarationMapJson
 
@@ -40,18 +42,13 @@ specPutStrLn =
     mkSpec "base" "System.IO" "putStrLn" ftPutStrLn
   where
     tyConIO = parsePprTyCon "ghc-prim-0.10.0:GHC.Types.IO"
-    tyConString = parsePprTyCon "base-4.18.0.0:GHC.Base.String"
     tyConAppIOUnit = Types.FgType_TyConApp tyConIO [Types.FgType_Unit Types.Boxed] -- IO ()
 
-    ftPutStrLn = Types.FunctionType
-            { Types.functionType_arg = Types.FgType_List $ Just $ Types.FgType_TyConApp tyConChar [] -- [Char]
-            , Types.functionType_ret = tyConAppIOUnit
-            }
-        -- , Json.typeInfo_unexpanded = Json.FunctionType
-        --     { Json.functionType_arg = Types.FgType_TyConApp tyConString [] -- String
-        --     , Json.functionType_ret = tyConAppIOUnit
-        --     }
-        -- }
+    ftPutStrLn =
+      Types.FunctionType
+        { Types.functionType_arg = Types.FgType_List $ Just $ Types.FgType_TyConApp tyConChar [] -- [Char]
+        , Types.functionType_ret = tyConAppIOUnit
+        }
 
 -- | Data.Text.unsnoc :: Text -> Maybe (Text, Char)
 specUnsnoc :: [Json.DeclarationMapJson T.Text] -> Test.Hspec.Spec
@@ -88,7 +85,7 @@ mkSpec pkgName modName defnName expected declarationMapJson =
         mTypeInfo = mDefnMap >>= Map.lookup defnName
         typeInfo = fromJust mTypeInfo
     mTypeInfo `shouldNotBe` Nothing
-    IgnorePackageVersion typeInfo `shouldBe` IgnorePackageVersion expected
+    IgnorePackageVersion typeInfo `shouldBe` IgnorePackageVersion (Types.Doodle.SomeFunction_Monomorphic expected)
 
 parsePprTyCon :: T.Text -> Types.FgTyCon T.Text
 parsePprTyCon = either error id . Types.parsePprTyCon
@@ -118,3 +115,29 @@ instance Eq (IgnorePackageVersion (Types.FunctionType (Types.FgType (Types.FgTyC
         strikePkgVersionTypeInfo ti = fmap strikePkgVersionFgType ti
 
     in strikePkgVersionTypeInfo ti1 == strikePkgVersionTypeInfo ti2
+
+instance Eq (IgnorePackageVersion (Types.Doodle.FunctionTypeForall T.Text T.Text)) where
+  IgnorePackageVersion ftf1 == IgnorePackageVersion ftf2 =
+    let strikePkgVersionFgPackage pkg = pkg { Types.fgPackageVersion = "" }
+
+        strikePkgVersionFgTyCon tc = tc {
+            Types.fgTyConPackage = strikePkgVersionFgPackage (Types.fgTyConPackage tc)
+          }
+
+        strikePkgVersionFgType fgt = fmap (first strikePkgVersionFgTyCon) fgt
+
+        strikePkgVersionFtf ftf =
+          ftf
+            { Types.Doodle.ftf_arg = strikePkgVersionFgType (Types.Doodle.ftf_arg ftf)
+            , Types.Doodle.ftf_ret = strikePkgVersionFgType (Types.Doodle.ftf_ret ftf)
+            }
+
+    in strikePkgVersionFtf ftf1 == strikePkgVersionFtf ftf2
+
+instance Eq (IgnorePackageVersion Types.Doodle.SomeFunction) where
+  IgnorePackageVersion sf1 == IgnorePackageVersion sf2 = case (sf1, sf2) of
+    (Types.Doodle.SomeFunction_Monomorphic sf1', Types.Doodle.SomeFunction_Monomorphic sf2') ->
+      IgnorePackageVersion sf1' == IgnorePackageVersion sf2'
+    (Types.Doodle.SomeFunction_Polymorphic sf1', Types.Doodle.SomeFunction_Polymorphic sf2') ->
+      IgnorePackageVersion sf1' == IgnorePackageVersion sf2'
+    _ -> False

--- a/dump-decls-exe/test/Spec.hs
+++ b/dump-decls-exe/test/Spec.hs
@@ -37,28 +37,26 @@ spec declarationMapJson =
 -- | System.IO.putStrLn :: String -> IO ()
 specPutStrLn :: [Json.DeclarationMapJson T.Text] -> Test.Hspec.Spec
 specPutStrLn =
-    mkSpec "base" "System.IO" "putStrLn" tiPutStrLn
+    mkSpec "base" "System.IO" "putStrLn" ftPutStrLn
   where
     tyConIO = parsePprTyCon "ghc-prim-0.10.0:GHC.Types.IO"
     tyConString = parsePprTyCon "base-4.18.0.0:GHC.Base.String"
     tyConAppIOUnit = Types.FgType_TyConApp tyConIO [Types.FgType_Unit Types.Boxed] -- IO ()
 
-    tiPutStrLn =
-      Json.TypeInfo
-        { Json.typeInfo_expanded = Just $ Json.FunctionType
+    ftPutStrLn = Json.FunctionType
             { Json.functionType_arg = Types.FgType_List $ Just $ Types.FgType_TyConApp tyConChar [] -- [Char]
             , Json.functionType_ret = tyConAppIOUnit
             }
-        , Json.typeInfo_unexpanded = Json.FunctionType
-            { Json.functionType_arg = Types.FgType_TyConApp tyConString [] -- String
-            , Json.functionType_ret = tyConAppIOUnit
-            }
-        }
+        -- , Json.typeInfo_unexpanded = Json.FunctionType
+        --     { Json.functionType_arg = Types.FgType_TyConApp tyConString [] -- String
+        --     , Json.functionType_ret = tyConAppIOUnit
+        --     }
+        -- }
 
 -- | Data.Text.unsnoc :: Text -> Maybe (Text, Char)
 specUnsnoc :: [Json.DeclarationMapJson T.Text] -> Test.Hspec.Spec
 specUnsnoc =
-    mkSpec "text" "Data.Text" "unsnoc" tiUnsnoc
+    mkSpec "text" "Data.Text" "unsnoc" funtionType
   where
     tyConText = parsePprTyCon "text-2.0.2:Data.Text.Internal.Text"
     fgTypeText = Types.FgType_TyConApp tyConText []
@@ -72,17 +70,11 @@ specUnsnoc =
           [Types.FgType_Tuple Types.Boxed 2 [fgTypeText, fgTypeChar]]
       }
 
-    tiUnsnoc =
-      Json.TypeInfo
-        { Json.typeInfo_expanded = Nothing
-        , Json.typeInfo_unexpanded = funtionType
-        }
-
 mkSpec
   :: T.Text -- Package with version (e.g. @base-4.18.0.0@)
   -> T.Text -- Module name (e.g. @System.IO@)
   -> T.Text -- Definition name (e.g. @putStrLn@)
-  -> Json.TypeInfo (Types.FgType (Types.FgTyCon T.Text))
+  -> Json.FunctionType (Types.FgType (Types.FgTyCon T.Text))
   -> [Json.DeclarationMapJson T.Text]
   -> Test.Hspec.Spec
 mkSpec pkgName modName defnName expected declarationMapJson =
@@ -113,7 +105,7 @@ tyConChar = parsePprTyCon "ghc-prim-0.10.0:GHC.Types.Char"
 newtype IgnorePackageVersion a = IgnorePackageVersion a
   deriving (Show)
 
-instance Eq (IgnorePackageVersion (Json.TypeInfo (Types.FgType (Types.FgTyCon T.Text)))) where
+instance Eq (IgnorePackageVersion (Json.FunctionType (Types.FgType (Types.FgTyCon T.Text)))) where
   IgnorePackageVersion ti1 == IgnorePackageVersion ti2 =
     let strikePkgVersionFgPackage pkg = pkg { Types.fgPackageVersion = "" }
 

--- a/dump-decls-exe/test/Spec.hs
+++ b/dump-decls-exe/test/Spec.hs
@@ -20,7 +20,7 @@ import qualified Data.List.NonEmpty as NE
 main :: IO ()
 main = do
   (stdout, ()) <- System.IO.Silently.capture $
-    withArgs ["base", "text"] Exe.main
+    withArgs ["/nix/store/icq948yaf8v17a464ciz38czigq0vccb-ghc-9.6.2/lib/ghc-9.6.2/lib", "base", "text"] Exe.main -- WIP!
   let stdoutBs = Data.ByteString.Lazy.Char8.pack stdout
   declarationMapJson :: [Json.DeclarationMapJson T.Text] <-
       either

--- a/dump-decls-exe/test/Spec.hs
+++ b/dump-decls-exe/test/Spec.hs
@@ -42,7 +42,7 @@ specPutStrLn =
   where
     tyConIO = parsePprTyCon "ghc-prim-0.10.0:GHC.Types.IO"
     tyConString = parsePprTyCon "base-4.18.0.0:GHC.Base.String"
-    tyConAppIOUnit = Types.FgType_TyConApp tyConIO [Types.FgType_Unit] -- IO ()
+    tyConAppIOUnit = Types.FgType_TyConApp tyConIO [Types.FgType_Unit Types.Boxed] -- IO ()
 
     tiPutStrLn =
       Json.TypeInfo

--- a/dump-decls-exe/test/Spec.hs
+++ b/dump-decls-exe/test/Spec.hs
@@ -15,7 +15,6 @@ import qualified Test.Hspec
 import Test.Hspec.Expectations.Pretty (shouldNotBe, shouldBe)
 import Data.Maybe (fromJust)
 import qualified Data.Map as Map
-import qualified Data.List.NonEmpty as NE
 
 main :: IO ()
 main = do
@@ -47,7 +46,7 @@ specPutStrLn =
     tiPutStrLn =
       Json.TypeInfo
         { Json.typeInfo_expanded = Just $ Json.FunctionType
-            { Json.functionType_arg = Types.FgType_List $ Types.FgType_TyConApp tyConChar [] -- [Char]
+            { Json.functionType_arg = Types.FgType_List $ Just $ Types.FgType_TyConApp tyConChar [] -- [Char]
             , Json.functionType_ret = tyConAppIOUnit
             }
         , Json.typeInfo_unexpanded = Json.FunctionType
@@ -70,7 +69,7 @@ specUnsnoc =
       { Json.functionType_arg = fgTypeText
       , Json.functionType_ret = Types.FgType_TyConApp
           tyConMaybe
-          [Types.FgType_Tuple Types.Boxed fgTypeText (NE.singleton fgTypeChar)]
+          [Types.FgType_Tuple Types.Boxed 2 [fgTypeText, fgTypeChar]]
       }
 
     tiUnsnoc =

--- a/dump-decls-exe/test/Spec.hs
+++ b/dump-decls-exe/test/Spec.hs
@@ -23,7 +23,7 @@ main = do
   (stdout, ()) <- System.IO.Silently.capture $
     withArgs ["/nix/store/icq948yaf8v17a464ciz38czigq0vccb-ghc-9.6.2/lib/ghc-9.6.2/lib", "base", "text"] Exe.main -- WIP!
   let stdoutBs = Data.ByteString.Lazy.Char8.pack stdout
-  declarationMapJson :: [Json.DeclarationMapJson T.Text] <-
+  declarationMapJson :: Exe.StdoutJsonFormat <-
       either
         (\e -> fail $ "JSON parse failure: " <> e)
         pure

--- a/dump-decls-lib/dump-decls-lib.cabal
+++ b/dump-decls-lib/dump-decls-lib.cabal
@@ -8,7 +8,8 @@ maintainer:         ben@smart-cactus.org
 copyright:          (c) 2023 Ben Gamari
 
 library
-    exposed-modules:  Json, Types, Compat, Compat.Aeson, Compat.Text
+    exposed-modules:  Json, Types, Types.Forall, Compat, Compat.Aeson, Compat.Text
+                    , Types.Doodle
     build-depends:    base
                     , containers
                     , aeson

--- a/dump-decls-lib/dump-decls-lib.cabal
+++ b/dump-decls-lib/dump-decls-lib.cabal
@@ -14,6 +14,7 @@ library
                     , containers
                     , aeson
                     , unordered-containers
+                    , ordered-containers
                     , text
                     , bytestring
                     , deepseq

--- a/dump-decls-lib/dump-decls-lib.cabal
+++ b/dump-decls-lib/dump-decls-lib.cabal
@@ -19,6 +19,7 @@ library
                     , bytestring
                     , deepseq
                     , utf8-string
+                    , vector
     hs-source-dirs:   src
     default-language: Haskell2010
     ghc-options:      -Wall

--- a/dump-decls-lib/src/Json.hs
+++ b/dump-decls-lib/src/Json.hs
@@ -5,9 +5,8 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE TupleSections #-}
 module Json
-( FunctionType(..)
-, ModuleDeclarations(..), fmapModuleDeclarations, explodeModuleDeclarations
-, DeclarationMapJson(..), fmapDeclarationMapJson
+( ModuleDeclarations(..), explodeModuleDeclarations
+, DeclarationMapJson(..)
   -- * Util
 , streamPrintJsonList
   -- * Re-exports
@@ -23,7 +22,8 @@ import qualified Data.Aeson as A
 import qualified Control.Exception as Ex
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.Map as Map
-import Types (FgType, FgTyCon, TyConParseError, FgPackage)
+import Types (TyConParseError, FgPackage)
+import qualified Types.Doodle as Doodle
 
 streamPrintJsonList
   :: A.ToJSON a
@@ -39,43 +39,20 @@ streamPrintJsonList jsonList =
         (map (BSL.putStrLn . A.encode) jsonList)
     )
 
-data FunctionType value = FunctionType
-  { functionType_arg :: value
-  , functionType_ret :: value
-  } deriving (Eq, Show, Ord, Functor, Foldable, Generic)
-
-instance A.ToJSON value => A.ToJSON (FunctionType value)
-instance A.FromJSON value => A.FromJSON (FunctionType value)
-instance NFData value => NFData (FunctionType value)
-
-instance Traversable FunctionType where
-  traverse f ft =
-    FunctionType <$> f (functionType_arg ft) <*> f (functionType_ret ft)
-
 data ModuleDeclarations value = ModuleDeclarations
-  { moduleDeclarations_map :: Map value (Map value (FunctionType (FgType (FgTyCon value))))
+  { moduleDeclarations_map :: Map value (Map value Doodle.SomeFunction) -- WIP: move somewhere else
     -- ^ Map from module name to a map of unqualified function names to 'TypeInfo'
-  , moduleDeclarations_mapFail :: Map value (Map value TyConParseError)
-    -- ^ Declarations for which an error occurred converting a 'GHC.Core.TyCon.TyCon' into a 'FgTyCon'.
-    --   This is probably a bug in 'Types.parsePprTyCon'.
+  , moduleDeclarations_mapFail :: Map value (Map value Doodle.FgError)
+    -- ^ TODO
   } deriving (Eq, Show, Ord, Generic)
 
 instance (A.ToJSON a, A.ToJSONKey a) => A.ToJSON (ModuleDeclarations a)
 instance (A.FromJSON a, A.FromJSONKey a, Ord a) => A.FromJSON (ModuleDeclarations a)
 instance (NFData a) => NFData (ModuleDeclarations a)
 
-fmapModuleDeclarations
-  :: Ord b
-  => (a -> b)
-  -> ModuleDeclarations a
-  -> ModuleDeclarations b
-fmapModuleDeclarations f (ModuleDeclarations map' mapFail) = ModuleDeclarations
-  (Map.mapKeys f (fmap (Map.mapKeys f . fmap (fmap (fmap (fmap f)))) map'))
-  (Map.mapKeys f (fmap (Map.mapKeys f) mapFail))
-
 explodeModuleDeclarations
   :: ModuleDeclarations value
-  -> [(value, (value, FunctionType (FgType (FgTyCon value))))]
+  -> [(value, (value, Doodle.SomeFunction))]
 explodeModuleDeclarations =
   concatMap (\(value, lst) -> map (value,) lst)
     . Map.toList
@@ -88,18 +65,6 @@ data DeclarationMapJson value = DeclarationMapJson
   } deriving (Eq, Generic, Show)
 
 instance NFData a => NFData (DeclarationMapJson a)
-
-fmapDeclarationMapJson
-  :: Ord b
-  => (a -> b)
-  -> DeclarationMapJson a
-  -> DeclarationMapJson b
-fmapDeclarationMapJson f dmj =
-  DeclarationMapJson
-    { declarationMapJson_package = f <$> declarationMapJson_package dmj
-    , declarationMapJson_moduleDeclarations = fmapModuleDeclarations f $ declarationMapJson_moduleDeclarations dmj
-
-    }
 
 instance (A.ToJSONKey value, A.ToJSON value) => A.ToJSON (DeclarationMapJson value)
 instance (Ord value, A.FromJSONKey value, A.FromJSON value) => A.FromJSON (DeclarationMapJson value)

--- a/dump-decls-lib/src/Json.hs
+++ b/dump-decls-lib/src/Json.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveFunctor #-}
@@ -7,7 +6,6 @@
 {-# LANGUAGE TupleSections #-}
 module Json
 ( FunctionType(..)
-, TypeInfo(..)
 , ModuleDeclarations(..), fmapModuleDeclarations, explodeModuleDeclarations
 , DeclarationMapJson(..), fmapDeclarationMapJson
   -- * Util
@@ -54,25 +52,8 @@ instance Traversable FunctionType where
   traverse f ft =
     FunctionType <$> f (functionType_arg ft) <*> f (functionType_ret ft)
 
-data TypeInfo tycon = TypeInfo
-  { typeInfo_expanded :: Maybe (FunctionType tycon)
-    -- ^ Does not contain type synonyms. 'Nothing' if there are no type synonyms in 'typeInfo_unexpanded'.
-  , typeInfo_unexpanded :: FunctionType tycon
-    -- ^ Potentially contains type synonyms
-  } deriving (Eq, Show, Ord, Functor, Foldable, Generic)
-
-instance (A.ToJSON tycon) => A.ToJSON (TypeInfo tycon)
-instance (A.FromJSON tycon) => A.FromJSON (TypeInfo tycon)
-instance (NFData tycon) => NFData (TypeInfo tycon)
-
-instance Traversable TypeInfo where
-  traverse f ti =
-    TypeInfo
-      <$> traverse (traverse f) (typeInfo_expanded ti)
-      <*> traverse f (typeInfo_unexpanded ti)
-
 data ModuleDeclarations value = ModuleDeclarations
-  { moduleDeclarations_map :: Map value (Map value (TypeInfo (FgType (FgTyCon value))))
+  { moduleDeclarations_map :: Map value (Map value (FunctionType (FgType (FgTyCon value))))
     -- ^ Map from module name to a map of unqualified function names to 'TypeInfo'
   , moduleDeclarations_mapFail :: Map value (Map value TyConParseError)
     -- ^ Declarations for which an error occurred converting a 'GHC.Core.TyCon.TyCon' into a 'FgTyCon'.
@@ -94,7 +75,7 @@ fmapModuleDeclarations f (ModuleDeclarations map' mapFail) = ModuleDeclarations
 
 explodeModuleDeclarations
   :: ModuleDeclarations value
-  -> [(value, (value, TypeInfo (FgType (FgTyCon value))))]
+  -> [(value, (value, FunctionType (FgType (FgTyCon value))))]
 explodeModuleDeclarations =
   concatMap (\(value, lst) -> map (value,) lst)
     . Map.toList

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -453,6 +453,7 @@ parsePackageWithVersion packageAndVersion = do
     splitByEndNonEmpty "invalid package identifier" '-' packageAndVersion
   pure $ FgPackage packageName packageVersion
 
+-- TODO: 
 -- | Parse a 'FgTyCon' from a 'GHC.Core.TyCon.TyCon' pretty-printed in fully-qualified form
 --  (e.g. "base-4.18.0.0:Data.Either.Either").
 --  The inverse of 'renderFgTyConQualified'.

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -387,7 +387,7 @@ renderFgTypeGeneric mkLiteral renderTycon fgType' =
 -- Examples:
 --
 -- >>> let Right ioTycon = parsePprTyCon "ghc-prim-0.10.0:GHC.Types.IO"
--- >>> renderFgTypeFgTyConUnqualified $ FgType_TyConApp ioTycon [FgType_Unit]
+-- >>> renderFgTypeFgTyConUnqualified $ FgType_TyConApp ioTycon [FgType_Unit Boxed]
 -- "IO ()"
 renderFgTypeFgTyConUnqualified
   :: FgType (FgTyCon T.Text)
@@ -400,7 +400,7 @@ renderFgTypeFgTyConUnqualified =
 -- Examples:
 --
 -- >>> let Right ioTycon = parsePprTyCon "ghc-prim-0.10.0:GHC.Types.IO"
--- >>> renderFgTypeFgTyConQualified $ FgType_TyConApp ioTycon [FgType_Unit]
+-- >>> renderFgTypeFgTyConQualified $ FgType_TyConApp ioTycon [FgType_Unit Boxed]
 -- "ghc-prim-0.10.0:GHC.Types.IO ()"
 renderFgTypeFgTyConQualified
   :: FgType (FgTyCon T.Text)
@@ -413,7 +413,7 @@ renderFgTypeFgTyConQualified =
 -- Examples:
 --
 -- >>> let Right ioTycon = parsePprTyCon "ghc-prim-0.10.0:GHC.Types.IO"
--- >>> renderFgTypeFgTyConQualifiedNoPackage $ FgType_TyConApp ioTycon [FgType_Unit]
+-- >>> renderFgTypeFgTyConQualifiedNoPackage $ FgType_TyConApp ioTycon [FgType_Unit Boxed]
 -- "GHC.Types.IO ()"
 renderFgTypeFgTyConQualifiedNoPackage
   :: FgType (FgTyCon T.Text)

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -7,12 +7,13 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE InstanceSigs #-}
 -- |
 -- TODO: Test 'Data.Aeson.encode
 -- TODO: Merge "Types" and "JSON"?
 module Types
 ( -- * 'FgType'
-  FgType(..), renderFgType, renderFgTypeGeneric
+  FgType(..), renderFgType, renderFgTypeGeneric, joinFgType
 , Boxity(..)
 , isBoxed
   -- * 'FgTyCon'
@@ -237,6 +238,35 @@ instance Traversable FgType where
       FgType_Tuple boxity size <$> traverse (traverse f) lst
     FgType_Unit b ->
       pure $ FgType_Unit b
+
+-- | Turn e.g. @(Either String) Int@ into @Either String Int@ (which are equivalent).
+--
+--   Similar to 'Control.Monad.join' hence the name.
+--
+--   Example:
+--
+-- >>> let nestedFgType = FgType_TyConApp (FgType_TyConApp "Either" [FgType_TyConApp "String" []]) [FgType_TyConApp (FgType_TyConApp "Int" []) []]
+-- >>> renderFgType (\fgType -> "(" <> renderFgType T.pack fgType <> ")") nestedFgType
+-- >>> renderFgType T.pack $ joinFgType nestedFgType
+-- "(Either String) (Int)"
+-- "Either Int String"
+joinFgType
+  :: FgType (FgType tyCon)
+  -> FgType tyCon
+joinFgType =
+  go
+  where
+    go = \case
+      FgType_TyConApp fgType args ->
+        case fgType of
+          FgType_TyConApp tyCon args' ->
+            FgType_TyConApp tyCon (map go args ++ args')
+          other -> other
+      FgType_List mFgType -> FgType_List $ go <$> mFgType
+      FgType_Tuple boxity size lst ->
+        FgType_Tuple boxity size $ go <$> lst
+      FgType_Unit b ->
+        FgType_Unit b
 
 -- | A /boxed/ value is one that's represented by a pointer to the actual data representing the value.
 --   An /unboxed/ value is represented by the actual data (no pointer).

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -327,7 +327,7 @@ instance (NFData tycon) => NFData (FgType tycon)
 -- >>> renderFgType id $ FgType_List $ FgType_Tuple Boxed (FgType_TyConApp "Key" []) (NE.singleton $ FgType_TyConApp "Value" [])
 -- "[(Key, Value)]"
 --
--- >>> renderFgType id $ FgType_TyConApp "Either" [FgType_TyConApp "String" [], FgType_TyConApp "IO" [FgType_Unit]]
+-- >>> renderFgType id $ FgType_TyConApp "Either" [FgType_TyConApp "String" [], FgType_TyConApp "IO" [FgType_Unit Boxed]]
 -- "Either String (IO ())"
 renderFgType
   :: forall tycon.
@@ -349,7 +349,7 @@ renderFgType = renderFgTypeGeneric id
 -- >>> let either' = FgTyCon "Either" "" (FgPackage "" "")
 -- >>> let text' = FgTyCon "Text" "" (FgPackage "" "")
 -- >>> let io' = FgTyCon "IO" "" (FgPackage "" "")
--- >>> let eitherStringValue = FgType_TyConApp either' [FgType_TyConApp text' [], FgType_TyConApp io' [FgType_Unit]]
+-- >>> let eitherStringValue = FgType_TyConApp either' [FgType_TyConApp text' [], FgType_TyConApp io' [FgType_Unit Boxed]]
 -- >>> renderFgTypeGeneric (\str -> TyConOrText [Left str]) (\tyCon -> TyConOrText [Right $ fgTyConName tyCon]) eitherStringValue
 -- TyConOrText [Right "Either",Left " ",Right "Text",Left " ",Left "(",Right "IO",Left " ",Left "()",Left ")"]
 renderFgTypeGeneric

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -16,7 +16,7 @@ module Types
 , Boxity(..)
 , isBoxed
   -- * 'FgTyCon'
-, FgTyCon(..), parsePprTyCon, renderFgTyConQualified, renderFgTyConQualifiedNoPackage, TyConParseError(..), renderTyConParseError, tgTyConHackageSrcUrl
+, FgTyCon(..), parsePprTyCon, renderFgTyConQualified, renderFgTyConQualifiedNoPackage, renderFgTyConUnqualified, TyConParseError(..), renderTyConParseError, tgTyConHackageSrcUrl
   -- * Rendering 'FgType (FgTyCon T.Text)'
 , renderFgTypeFgTyConUnqualified, renderFgTypeFgTyConQualified, renderFgTypeFgTyConQualifiedNoPackage, fgTypeHackageSrcUrlsHtml
   -- * 'FgPackage'
@@ -94,6 +94,12 @@ renderFgTyConQualifiedNoPackage tc =
     , "."
     , fgTyConName tc
     ]
+
+-- TODO: docs
+renderFgTyConUnqualified
+  :: FgTyCon T.Text
+  -> T.Text
+renderFgTyConUnqualified = fgTyConName
 
 -- | Render as Hackage source URL.
 --

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -209,7 +209,7 @@ data FgType tycon
   -- ^ A list
   | FgType_Tuple Boxity (FgType tycon) (NE.NonEmpty (FgType tycon))
   -- ^ A tuple of size @1 + length nonEmptyList@
-  | FgType_Unit Boxity
+  | FgType_Unit Boxity -- TODO: Replace 'Boxity' argument with an additional `FgType_UnboxedUnit` constructor?
   -- ^ Unit ('()')
     deriving (Eq, Show, Ord, Foldable, Generic)
 

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -26,7 +26,6 @@ module Types
 )
 where
 
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Aeson as A
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
@@ -268,13 +267,13 @@ instance A.FromJSON Boxity where
 instance (A.ToJSON tycon) => A.ToJSON (FgType tycon) where
   toJSON = \case
     FgType_TyConApp tycon tyList -> A.object
-      [("type", A.object [("tycon" :: Compat.Key, A.toJSON tycon), ("tycon_args", A.toJSON tyList)])]
+      [("type", A.object [("tycon" :: Compat.Key, A.toJSON tycon), ("args", A.toJSON tyList)])]
     FgType_List bty -> A.object
       [("list", A.toJSON bty)]
     FgType_Tuple boxity size args -> -- WIP: size
       let key = case boxity of {Unboxed -> "tuple#"; Boxed -> "tuple"}
       in A.object
-        [(key, A.toJSON args)]
+        [(key, A.object [("args", A.toJSON args), ("size", A.toJSON size)])]
     FgType_Unit b -> A.String $ "unit" <> if b == Unboxed then "#" else ""
 
 instance (A.FromJSON tycon) => A.FromJSON (FgType tycon) where
@@ -285,10 +284,10 @@ instance (A.FromJSON tycon) => A.FromJSON (FgType tycon) where
     val -> failParse val
     where
       parseObject o = do
-            parseKind o "type" (\o' ->  FgType_TyConApp <$> o' A..: "tycon" <*> o' A..: "tycon_args")
+            parseKind o "type" (\o' -> FgType_TyConApp <$> o' A..: "tycon" <*> o' A..: "args")
         <|> parseKind o "list" (pure . FgType_List)
-        <|> parseKind o "tuple" (tupleFromList Boxed)
-        <|> parseKind o "tuple#" (tupleFromList Unboxed)
+        <|> parseKind o "tuple" (tupleFromObject Boxed)
+        <|> parseKind o "tuple#" (tupleFromObject Unboxed)
         <|> failParse (A.Object o)
 
       failParse val = fail $ unwords
@@ -312,9 +311,14 @@ instance (A.FromJSON tycon) => A.FromJSON (FgType tycon) where
       parseKind o keyTxt mkType =
         maybe empty (A.parseJSON >=> mkType) (Compat.lookup keyTxt o)
 
-      tupleFromList boxity = \case
+      tupleFromObject boxity o = do
+        size <- o A..: "size"
+        args <- o A..: "args"
+        tupleFromArgList size boxity args
+
+      tupleFromArgList size boxity = \case
         args@(_:_:_) ->
-          pure $ FgType_Tuple boxity (error "WIP: size") args
+          pure $ FgType_Tuple boxity size args
         other ->
           fail $ "Tuple size must be >= 2 but size is: " <> show (length other)
 

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -23,7 +23,7 @@ module Types
   -- * 'FgPackage'
 , FgPackage(..), parsePackageWithVersion, renderFgPackage
   -- * 'FunctionType'
-, FunctionType(..)
+, FunctionType(..), renderFunctionTypeMono, renderFunctionTypeMonoGeneric
   -- * (For testing)
 , splitByEndNonEmpty,
 )
@@ -565,6 +565,19 @@ instance NFData value => NFData (FunctionType value)
 instance Traversable FunctionType where
   traverse f ft =
     FunctionType <$> f (functionType_arg ft) <*> f (functionType_ret ft)
+
+renderFunctionTypeMono :: FunctionType (FgType (FgTyCon T.Text)) -> T.Text
+renderFunctionTypeMono =
+  renderFunctionTypeMonoGeneric renderFgTyConQualified
+
+renderFunctionTypeMonoGeneric
+  :: (FgTyCon T.Text -> T.Text)
+  -> FunctionType (FgType (FgTyCon T.Text)) -> T.Text
+renderFunctionTypeMonoGeneric renderTyCon ft = T.unwords
+  [ renderFgType renderTyCon (functionType_arg ft)
+  , "->"
+  , renderFgType renderTyCon (functionType_ret ft)
+  ]
 
 -- | Split string by last occurence of character.
 --   Return pair of non-empty text strings before and after character (neither string includes the character).

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -22,6 +22,8 @@ module Types
 , renderFgTypeFgTyConUnqualified, renderFgTypeFgTyConQualified, renderFgTypeFgTyConQualifiedNoPackage, fgTypeHackageSrcUrlsHtml
   -- * 'FgPackage'
 , FgPackage(..), parsePackageWithVersion, renderFgPackage
+  -- * 'FunctionType'
+, FunctionType(..)
   -- * (For testing)
 , splitByEndNonEmpty,
 )
@@ -550,6 +552,19 @@ parsePprTyCon str = do
     , fgTyConModule = moduleName
     , fgTyConPackage = package
     }
+
+data FunctionType value = FunctionType
+  { functionType_arg :: value
+  , functionType_ret :: value
+  } deriving (Eq, Show, Ord, Functor, Foldable, Generic)
+
+instance A.ToJSON value => A.ToJSON (FunctionType value)
+instance A.FromJSON value => A.FromJSON (FunctionType value)
+instance NFData value => NFData (FunctionType value)
+
+instance Traversable FunctionType where
+  traverse f ft =
+    FunctionType <$> f (functionType_arg ft) <*> f (functionType_ret ft)
 
 -- | Split string by last occurence of character.
 --   Return pair of non-empty text strings before and after character (neither string includes the character).

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -205,10 +205,14 @@ data FgType tycon
       --  (e.g. 'Int', 'Char', 'Data.Text.Text') and otherwise one type for all type variables
       --  of the type constructor (since we're only looking at the types of functions
       --  exported from a module where a partially applied type constructor is invalid).
-  | FgType_List (FgType tycon)
+  | FgType_List (Maybe (FgType tycon))
   -- ^ A list
-  | FgType_Tuple Boxity (FgType tycon) (NE.NonEmpty (FgType tycon))
-  -- ^ A tuple of size @1 + length nonEmptyList@
+  --
+  --   TODO: why 'Maybe'?
+  | FgType_Tuple -- A tuple
+      Boxity
+      Word -- ^ Size
+      [FgType tycon] -- Arguments (not necessarily saturated)
   | FgType_Unit Boxity -- TODO: Replace 'Boxity' argument with an additional `FgType_UnboxedUnit` constructor?
   -- ^ Unit ('()')
     deriving (Eq, Show, Ord, Foldable, Generic)
@@ -218,9 +222,9 @@ instance Functor FgType where
     FgType_TyConApp tycon tyList ->
       FgType_TyConApp (f tycon) (map (fmap f) tyList)
     FgType_List bty ->
-      FgType_List $ fmap f bty
-    FgType_Tuple boxity bty neBty ->
-      FgType_Tuple boxity (fmap f bty) (NE.map (fmap f) neBty)
+      FgType_List $ fmap (fmap f) bty
+    FgType_Tuple boxity size lst ->
+      FgType_Tuple boxity size (map (fmap f) lst)
     FgType_Unit b ->
       FgType_Unit b
 
@@ -229,9 +233,9 @@ instance Traversable FgType where
     FgType_TyConApp tycon tyList ->
       FgType_TyConApp <$> f tycon <*> traverse (traverse f) tyList
     FgType_List bty ->
-      FgType_List <$> traverse f bty
-    FgType_Tuple boxity bty neBty ->
-      FgType_Tuple boxity <$> traverse f bty <*> traverse (traverse f) neBty
+      FgType_List <$> traverse (traverse f) bty
+    FgType_Tuple boxity size lst ->
+      FgType_Tuple boxity size <$> traverse (traverse f) lst
     FgType_Unit b ->
       pure $ FgType_Unit b
 
@@ -267,10 +271,10 @@ instance (A.ToJSON tycon) => A.ToJSON (FgType tycon) where
       [("type", A.object [("tycon" :: Compat.Key, A.toJSON tycon), ("tycon_args", A.toJSON tyList)])]
     FgType_List bty -> A.object
       [("list", A.toJSON bty)]
-    FgType_Tuple boxity bty neBty ->
+    FgType_Tuple boxity size args -> -- WIP: size
       let key = case boxity of {Unboxed -> "tuple#"; Boxed -> "tuple"}
       in A.object
-        [(key, A.toJSON $ bty : NE.toList neBty)]
+        [(key, A.toJSON args)]
     FgType_Unit b -> A.String $ "unit" <> if b == Unboxed then "#" else ""
 
 instance (A.FromJSON tycon) => A.FromJSON (FgType tycon) where
@@ -309,8 +313,8 @@ instance (A.FromJSON tycon) => A.FromJSON (FgType tycon) where
         maybe empty (A.parseJSON >=> mkType) (Compat.lookup keyTxt o)
 
       tupleFromList boxity = \case
-        ty1:ty2:tyTail ->
-          pure $ FgType_Tuple boxity ty1 (ty2 NE.:| tyTail)
+        args@(_:_:_) ->
+          pure $ FgType_Tuple boxity (error "WIP: size") args
         other ->
           fail $ "Tuple size must be >= 2 but size is: " <> show (length other)
 
@@ -324,11 +328,15 @@ instance (NFData tycon) => NFData (FgType tycon)
 -- >>> renderFgType id $ FgType_TyConApp "Either" [FgType_TyConApp "String" [], FgType_TyConApp "Value" []]
 -- "Either String Value"
 --
--- >>> renderFgType id $ FgType_List $ FgType_Tuple Boxed (FgType_TyConApp "Key" []) (NE.singleton $ FgType_TyConApp "Value" [])
+-- >>> renderFgType id $ FgType_List $ Just $ FgType_Tuple Boxed 2 [FgType_TyConApp "Key" [], FgType_TyConApp "Value" []]
 -- "[(Key, Value)]"
 --
 -- >>> renderFgType id $ FgType_TyConApp "Either" [FgType_TyConApp "String" [], FgType_TyConApp "IO" [FgType_Unit Boxed]]
 -- "Either String (IO ())"
+--
+-- Example: unsaturated tuple:
+-- >>> renderFgType id $ FgType_Tuple Boxed 4 [FgType_TyConApp "String" [], FgType_TyConApp "Int" []]
+-- "(,,,) String Int"
 renderFgType
   :: forall tycon.
      (tycon -> T.Text)
@@ -372,10 +380,17 @@ renderFgTypeGeneric mkLiteral renderTycon fgType' =
       FgType_TyConApp tycon fgTypeList ->
         (if not (null fgTypeList) && parenthesize then parens else id) $
           mconcat $ Data.List.intersperse (mkLiteral " ") $ renderTycon tycon : map (go True) fgTypeList
-      FgType_List fgType ->
+      FgType_List Nothing ->
+        mkLiteral "[]"
+      FgType_List (Just fgType) ->
         mkLiteral "[" <> go False fgType <> mkLiteral "]"
-      FgType_Tuple boxity fgType fgTypeList ->
-        tupleParens boxity $ mconcat $ Data.List.intersperse (mkLiteral ", ") $ map (go False) (fgType : NE.toList fgTypeList)
+      FgType_Tuple boxity size fgTypeList | length fgTypeList == fromIntegral size ->
+        tupleParens boxity $ mconcat $ Data.List.intersperse (mkLiteral ", ") $ map (go False) fgTypeList
+      FgType_Tuple boxity size fgTypeList -> -- unsaturated or over-saturated
+        mconcat $ Data.List.intersperse (mkLiteral " ") $
+          tupleParens boxity (mconcat $ Data.List.replicate (fromIntegral size - 1) (mkLiteral ","))
+
+          : map (go True) fgTypeList
       FgType_Unit Boxed ->
         mkLiteral "()"
       FgType_Unit Unboxed ->

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -246,10 +246,10 @@ instance Traversable FgType where
 --   Example:
 --
 -- >>> let nestedFgType = FgType_TyConApp (FgType_TyConApp "Either" [FgType_TyConApp "String" []]) [FgType_TyConApp (FgType_TyConApp "Int" []) []]
--- >>> renderFgType (\fgType -> "(" <> renderFgType T.pack fgType <> ")") nestedFgType
--- >>> renderFgType T.pack $ joinFgType nestedFgType
--- "(Either String) (Int)"
--- "Either Int String"
+-- >>> let inputRendered = renderFgType (\fgType -> "(" <> renderFgType T.pack fgType <> ")") nestedFgType
+-- >>> let outputRendered = renderFgType T.pack $ joinFgType nestedFgType
+-- >>> inputRendered <> " / " <> outputRendered
+-- "(Either String) (Int) / Either Int String"
 joinFgType
   :: FgType (FgType tyCon)
   -> FgType tyCon

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -203,7 +203,7 @@ data FgType tycon
   -- ^ A list
   | FgType_Tuple Boxity (FgType tycon) (NE.NonEmpty (FgType tycon))
   -- ^ A tuple of size @1 + length nonEmptyList@
-  | FgType_Unit
+  | FgType_Unit Boxity
   -- ^ Unit ('()')
     deriving (Eq, Show, Ord, Foldable, Generic)
 
@@ -215,8 +215,8 @@ instance Functor FgType where
       FgType_List $ fmap f bty
     FgType_Tuple boxity bty neBty ->
       FgType_Tuple boxity (fmap f bty) (NE.map (fmap f) neBty)
-    FgType_Unit ->
-      FgType_Unit
+    FgType_Unit b ->
+      FgType_Unit b
 
 instance Traversable FgType where
   traverse f = \case
@@ -226,8 +226,8 @@ instance Traversable FgType where
       FgType_List <$> traverse f bty
     FgType_Tuple boxity bty neBty ->
       FgType_Tuple boxity <$> traverse f bty <*> traverse (traverse f) neBty
-    FgType_Unit ->
-      pure FgType_Unit
+    FgType_Unit b ->
+      pure $ FgType_Unit b
 
 -- | A /boxed/ value is one that's represented by a pointer to the actual data representing the value.
 --   An /unboxed/ value is represented by the actual data (no pointer).
@@ -265,11 +265,12 @@ instance (A.ToJSON tycon) => A.ToJSON (FgType tycon) where
       let key = case boxity of {Unboxed -> "tuple#"; Boxed -> "tuple"}
       in A.object
         [(key, A.toJSON $ bty : NE.toList neBty)]
-    FgType_Unit -> A.String "unit"
+    FgType_Unit b -> A.String $ "unit" <> if b == Unboxed then "#" else ""
 
 instance (A.FromJSON tycon) => A.FromJSON (FgType tycon) where
   parseJSON = \case
-    A.String "unit" -> pure FgType_Unit
+    A.String "unit" -> pure $ FgType_Unit Boxed
+    A.String "unit#" -> pure $ FgType_Unit Boxed
     A.Object o -> parseObject o
     val -> failParse val
     where
@@ -369,8 +370,10 @@ renderFgTypeGeneric mkLiteral renderTycon fgType' =
         mkLiteral "[" <> go False fgType <> mkLiteral "]"
       FgType_Tuple boxity fgType fgTypeList ->
         tupleParens boxity $ mconcat $ Data.List.intersperse (mkLiteral ", ") $ map (go False) (fgType : NE.toList fgTypeList)
-      FgType_Unit ->
+      FgType_Unit Boxed ->
         mkLiteral "()"
+      FgType_Unit Unboxed ->
+        tupleParens Unboxed (mkLiteral " ")
   in go False fgType'
 
 -- | Render only the 'fgTyConName' of the 'FgTyCon'.

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -184,6 +184,7 @@ renderTyConParseError e = T.unwords
 --   More will be added later, probably.
 --
 --   Type constructors that have special syntax are handled separately: lists, tuples, unit.
+-- TODO: consider splitting into (1) FgType_TyConApp, and (2) the "special types" list/tuple/unit
 data FgType tycon
   = FgType_TyConApp
     -- ^ A type consisting of (1) a type constructor,

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -453,7 +453,6 @@ parsePackageWithVersion packageAndVersion = do
     splitByEndNonEmpty "invalid package identifier" '-' packageAndVersion
   pure $ FgPackage packageName packageVersion
 
--- TODO: 
 -- | Parse a 'FgTyCon' from a 'GHC.Core.TyCon.TyCon' pretty-printed in fully-qualified form
 --  (e.g. "base-4.18.0.0:Data.Either.Either").
 --  The inverse of 'renderFgTyConQualified'.

--- a/dump-decls-lib/src/Types.hs
+++ b/dump-decls-lib/src/Types.hs
@@ -478,8 +478,12 @@ parsePackageWithVersion packageAndVersion = do
 parsePprTyCon :: T.Text -> Either String (FgTyCon T.Text)
 parsePprTyCon str = do
   (packageAndVersion, fqn) <- case T.splitOn ":" str of
-    [packageAndVersion, fqn] -> pure (packageAndVersion, fqn)
-    _ -> Left $ "missing colon in " <> show (T.unpack str)
+    packageAndVersion : fqnLst@(_ : _) ->
+      -- NOTE: if the type constructor name contains one or more colons, then we need to restore these after splitting on the colon that follows the package name/version
+      let fqn = mconcat $ Data.List.intersperse ":" fqnLst
+      in pure (packageAndVersion, fqn)
+    _ ->
+      Left $ "missing colon in " <> show (T.unpack str)
   package <- parsePackageWithVersion packageAndVersion
   (moduleName, name) <-
     splitByEndNonEmpty "invalid fully qualified identifier" '.' fqn

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -14,6 +14,12 @@ data TyConWithVar tyVar text
   = TyCon (FgTyCon text)
   | TyVar (TyVar tyVar)
 
+eitherToTyConWithVar
+  :: Either (FgTyCon text) (TyVar tyVar)
+  -> TyConWithVar tyVar text
+eitherToTyConWithVar =
+  either TyCon TyVar
+
 data FunctionTypeForall tyVar text = FunctionTypeForall
   { ftf_forall :: Forall T.Text
   , ftf_arg :: FgType (TyConWithVar tyVar text)

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -10,18 +10,8 @@ import qualified Data.Text as T
 type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
 
-data TyConWithVar tyVar text
-  = TyCon (FgTyCon text)
-  | TyVar (TyVar tyVar)
-
-eitherToTyConWithVar
-  :: Either (FgTyCon text) (TyVar tyVar)
-  -> TyConWithVar tyVar text
-eitherToTyConWithVar =
-  either TyCon TyVar
-
 data FunctionTypeForall tyVar text = FunctionTypeForall
   { ftf_forall :: Forall T.Text
-  , ftf_arg :: FgType (TyConWithVar tyVar text)
-  , ftf_ret :: FgType (TyConWithVar tyVar text)
+  , ftf_arg :: FgType (Either (FgTyCon text) (TyVar tyVar))
+  , ftf_ret :: FgType (Either (FgTyCon text) (TyVar tyVar))
   }

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -1,0 +1,21 @@
+module Types.Doodle
+
+where
+
+import Types
+import Types.Forall
+import Json
+import qualified Data.Text as T
+
+type FunctionTypeNoTyVar =
+  FunctionType (FgType (FgTyCon T.Text))
+
+data TyConWithVar tyVar text
+  = TyCon (FgTyCon text)
+  | TyVar (TyVar tyVar)
+
+data FunctionTypeForall tyVar text = FunctionTypeForall
+  { ftf_forall :: Forall T.Text
+  , ftf_arg :: FgType (TyConWithVar tyVar text)
+  , ftf_ret :: FgType (TyConWithVar tyVar text)
+  }

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -6,10 +6,11 @@
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 {-# HLINT ignore "Use <$>" #-}
 {-# LANGUAGE TypeOperators #-}
+{-# HLINT ignore "Use first" #-}
 module Types.Doodle
 ( FunctionTypeForall(..)
+, specializeType
 )
-
 where
 
 import Types
@@ -19,6 +20,8 @@ import qualified Data.Text as T
 import Data.Foldable (foldl')
 import qualified Data.Map as Map
 import Control.Monad (foldM)
+import Data.Bifunctor (first)
+import Data.Functor ((<&>))
 
 type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
@@ -76,7 +79,16 @@ extendFrom =
 -- >>> let withoutTyVars = FgType_TyConApp "Map" [FgType_TyConApp "Bool" [], FgType_TyConApp "Int" []]
 -- >>> specializeType withTyVars withoutTyVars
 -- Right (Just (FgType_TyConApp "Map" [FgType_TyConApp "Bool" [],FgType_TyConApp "Int" []],fromList [("a",FgType_TyConApp "Bool" []),("b",FgType_TyConApp "Int" []),("f",FgType_TyConApp "Map" [])]))
-
+--
+-- >>> specializeType (FgType_Tuple Boxed 2 [FgType_TyConApp (Right "int") [], FgType_TyConApp (Right "bool") []]) (FgType_Tuple Boxed 2 [FgType_TyConApp (Left "Int") [], FgType_TyConApp (Left "Bool") []])
+-- Right (Just (FgType_Tuple Boxed 2 [FgType_TyConApp (Left "Int") [],FgType_TyConApp (Left "Bool") []],fromList [("bool",FgType_TyConApp (Left "Bool") []),("int",FgType_TyConApp (Left "Int") [])]))
+--
+-- NOTE: Implementaion strategy:
+--    1. Prefer many small, specific matches over few generic matches,
+--       e.g. separately match on `Right tyVar` and `Left tyCon`.
+--       If this leads to code duplication then factor out common code into a helper function.
+--    2. No wildcard matches. Match constructors only until no warnings are left.
+--       Helps to ensure that no relevant case has been overlooked.
 specializeType
   :: forall tyCon tyVar.
      ( Eq tyCon
@@ -102,38 +114,112 @@ specializeType =
        -> _
        -> Either String (Maybe (FgType tyCon, Map tyVar (FgType tyCon)))
     go env poly mono =
-      let handleTyConWithArgs' = handleTyConWithArgs (poly, mono) env
+      let handleTyConArgs' = handleTyConArgs (poly, mono)
       in case (poly, mono) of
-        (FgType_TyConApp pTyCon pArgs, FgType_TyConApp mTyCon mArgs) -> -- (Map k v) (Map Bool Int)
-          handleTyConWithArgs' (pTyCon, pArgs) (mTyCon, mArgs)
+        (FgType_TyConApp (Left pTyCon) pArgs, FgType_TyConApp mTyCon mArgs) | pTyCon == mTyCon -> do -- (Either a b, Either Int Bool)
+          mResult <- handleTyConArgs' env pArgs mArgs
+          pure $ first (FgType_TyConApp mTyCon) <$> mResult
 
-        (FgType_TyConApp _ _, _) ->
+        (FgType_TyConApp (Left _) _, FgType_TyConApp _ _) -> -- (Map a b, Either Int Bool)
+          Right Nothing -- NOTE: pTyCon /= mTyCon
+
+        (FgType_TyConApp (Right tyVar) pArgs, FgType_TyConApp mTyCon mArgs) ->
+          let mTyCon' =
+                let mTyConFgType = FgType_TyConApp mTyCon []
+                in case Map.lookup tyVar env of
+                  Just existingTypeEq ->
+                    if existingTypeEq == mTyConFgType
+                      then Just (mTyCon, env) -- previously instantiated to the same type. NOTE: unless `mArgs == []` this is a type variable _NOT_ of kind *
+                      else Nothing -- this type variable was previously instantiated to something else
+                  Nothing ->
+                    Just (mTyCon, Map.insert tyVar mTyConFgType env)
+          in case mTyCon' of
+              Just (tyCon', env') -> do
+                fmap (first (FgType_TyConApp tyCon')) <$> handleTyConArgs' env' pArgs mArgs
+              Nothing -> Right Nothing
+
+        (FgType_TyConApp (Right tyVar) [], ty@(FgType_List _)) -> -- f [] ; a [Int] ; a [b]
+          Right $ Just (ty, Map.insert tyVar ty env)
+
+        (FgType_TyConApp (Right tyVar) [tyVarArg], FgType_List (Just lstArg)) -> -- (f a, [Int]) ; (f a, [[Int]])
+          let env' = Map.insert tyVar (FgType_List Nothing) env -- f ~ []
+          in do
+            mResult <- go env' tyVarArg lstArg
+            pure $ mResult <&> \(resultArg, env'') -> (FgType_List (Just resultArg), env'')
+
+        (FgType_TyConApp (Right _) (_:_:_), FgType_List _) -> -- (f a b [...], []) ; (f a b [...], [Int])
           Right Nothing
 
-        (FgType_List _, FgType_List _) -> -- [a] [Bool]
-          undefined
+        (FgType_TyConApp (Right _) [_], FgType_List Nothing) -> -- (f a, [])
+          Right Nothing
+
+        (FgType_TyConApp (Right tyVar) [], fgTuple@(FgType_Tuple{})) -> -- (a, (Int, Bool)) ; (f, (,)) ; (f, (,) Bool)
+          Right $ Just (fgTuple, Map.insert tyVar fgTuple env)
+
+        (FgType_TyConApp (Right tyVar) pArgs, FgType_Tuple boxity size args) | length pArgs == length args -> do -- (f a, (,) Bool) ; f a a, (,) Bool Bool) ; (f a b c, (,) Int Bool String)
+          let env' = Map.insert tyVar (FgType_Tuple boxity size []) env
+          mRes <- handleTyConArgs' env' pArgs args
+          pure $ mRes <&> \(result, env'') ->
+            (FgType_Tuple boxity size result, env'')
+
+        (FgType_TyConApp (Right _) _, FgType_Tuple{}) -> -- (f a, (,) Bool Int) ; (f a b, (,) Bool)
+          Right Nothing -- NOTE: length pArgs /= length args
+
+        (FgType_TyConApp (Right tyVar) [], fgUnit@FgType_Unit{}) -> -- a ()
+          Right $ Just (fgUnit, Map.insert tyVar fgUnit env)
+
+        (FgType_TyConApp (Right _) _, FgType_Unit{}) -> -- (f a, ())
+          Right Nothing
+
+        (FgType_TyConApp (Left _) _, FgType_List{}) ->
+          Right Nothing
+        (FgType_TyConApp (Left _) _, FgType_Tuple{}) ->
+          Right Nothing
+        (FgType_TyConApp (Left _) _, FgType_Unit{}) ->
+          Right Nothing
+
+        (FgType_List (Just fgType), FgType_List (Just fgType')) -> do -- [a] [Bool]
+          mResult <- go env fgType fgType'
+          pure $ mResult <&> \(result, env') ->
+            (FgType_List (Just result), env')
 
         (FgType_List _, _) ->
           Right Nothing
 
-        (FgType_Tuple _ _ _, FgType_Tuple _ _ _) -> -- (a, b) (a, Bool)
-          undefined
-
-        (FgType_Tuple _ _ _, _) ->
+        (FgType_Tuple boxity size args, FgType_Tuple boxity' size' args') | boxity == boxity' && size == size' -> do -- (a, b) (Int, Bool)
+          mArgsEnv <- handleTyConArgs' env args args'
+          pure $ mArgsEnv <&> first (FgType_Tuple boxity size)
+        (FgType_Tuple{}, FgType_Tuple{}) -> -- boxity /= boxity' || size /= size'
           Right Nothing
 
-        (FgType_Unit _, _) ->
+        (FgType_Tuple _ _ _, FgType_TyConApp _ _) ->
+          Right Nothing
+        (FgType_Tuple _ _ _, FgType_List _) ->
+          Right Nothing
+        (FgType_Tuple _ _ _, FgType_Unit _) ->
           Right Nothing
 
-    handleTyConWithArgs
+        (FgType_Unit b, fgUnit@(FgType_Unit b')) | b == b' ->
+          Right $ Just (fgUnit, env)
+
+        (FgType_Unit{}, FgType_Unit{}) -> -- boxity mismatch
+          Right Nothing
+        (FgType_Unit _, FgType_TyConApp{}) ->
+          Right Nothing
+        (FgType_Unit _, FgType_List{}) ->
+          Right Nothing
+        (FgType_Unit _, FgType_Tuple{}) ->
+          Right Nothing
+
+    handleTyConArgs
       :: forall env.
          env ~ Map tyVar (FgType tyCon)
       => (FgType (Either tyCon tyVar), FgType tyCon) -- For debug printing
       -> env
-      -> (Either tyCon tyVar, [FgType (Either tyCon tyVar)]) -- polymorphic (TyCon, TyCon args)
-      -> (tyCon, [FgType tyCon]) -- monomorphic (TyCon, TyCon args)
-      -> Either String (Maybe (FgType tyCon, env))
-    handleTyConWithArgs dbg env_ (pTyCon, pArgs) (mTyCon, mArgs) =
+      -> [FgType (Either tyCon tyVar)] -- polymorphic TyCon args
+      -> [FgType tyCon] -- monomorphic TyCon args
+      -> Either String (Maybe ([FgType tyCon], env))
+    handleTyConArgs dbg env_ pArgs mArgs =
       let matchTyConArg
             :: Maybe ([FgType tyCon], env)
             -> (FgType (Either tyCon tyVar), FgType tyCon)
@@ -147,29 +233,13 @@ specializeType =
             other -> pure other
 
           eTyConArgsResult env'
-            | length mArgs /= length pArgs =
+            | length mArgs /= length pArgs = -- WIP: do we handle this now?
                 Left $ "unsaturated type constructor. " <> show dbg
             | otherwise =
                 foldM matchTyConArg (Just ([], env')) (zip pArgs mArgs)
+      in do
+        mResultArgs <- eTyConArgsResult env_
+        Right $ do
+          (resultArgs, env'') <- mResultArgs
+          Just (reverse resultArgs, env'')
 
-          mTyCon'
-            | pTyCon == Left mTyCon =
-                Just (mTyCon, env_) -- both lhs and rhs are the same type constructor.
-            | Right tyVar <- pTyCon = -- lhs is tyvar
-                let blahType = FgType_TyConApp mTyCon [] -- WIP: name
-                in case Map.lookup tyVar env_ of
-                  Just existingTypeEq ->
-                    if existingTypeEq == blahType
-                      then Just (mTyCon, env_) -- previously instantiated to the same type. NOTE: unless `mArgs == []` this is a type variable _NOT_ of kind *
-                      else Nothing -- this type variable was previously instantiated to something else
-                  Nothing ->
-                    Just (mTyCon, Map.insert tyVar blahType env_)
-            | otherwise =
-                Nothing -- lhs and rhs are different type constructors
-      in case mTyCon' of
-        Just (tyCon', env') -> do
-          mResultArgs <- eTyConArgsResult env'
-          Right $ do
-            (resultArgs, env'') <- mResultArgs
-            Just (FgType_TyConApp tyCon' (reverse resultArgs), env'')
-        _ -> Right Nothing

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -11,7 +11,7 @@ type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
 
 data FunctionTypeForall tyVar text = FunctionTypeForall
-  { ftf_forall :: Forall text
+  { ftf_forall :: Forall T.Text
   , ftf_arg :: FgType (Either (FgTyCon text) (TyVar tyVar))
   , ftf_ret :: FgType (Either (FgTyCon text) (TyVar tyVar))
   }

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -1,4 +1,14 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use record patterns" #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+{-# HLINT ignore "Use <$>" #-}
+{-# LANGUAGE TypeOperators #-}
 module Types.Doodle
+( FunctionTypeForall(..)
+)
 
 where
 
@@ -6,6 +16,9 @@ import Types
 import Types.Forall
 import Json
 import qualified Data.Text as T
+import Data.Foldable (foldl')
+import qualified Data.Map as Map
+import Control.Monad (foldM)
 
 type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
@@ -15,3 +28,148 @@ data FunctionTypeForall tyVar text = FunctionTypeForall
   , ftf_arg :: FgType (Either (FgTyCon text) (TyVar tyVar))
   , ftf_ret :: FgType (Either (FgTyCon text) (TyVar tyVar))
   }
+
+-- |
+extendFrom
+  :: [FunctionTypeNoTyVar]
+      -- ^ monomorphic functions.
+      --
+      --   e.g. @Int -> [Bool]@
+  -> [FunctionTypeForall tyVar text]
+      -- ^ polymorphic functions
+      --
+      --   e.g. @forall a. [a] -> Maybe a@
+  -> [FunctionTypeNoTyVar]
+      -- ^ a list of: a specialization of a polymorphic function
+      --    that takes as argument a type retuned by one of the monomorphic functions
+      --
+      --  e.g. @[Bool] -> Maybe Bool@
+extendFrom =
+  undefined
+
+-- | TODO
+--
+--   Example 1: Map k v / Map Bool Int: [k ~ Bool, v ~ Int]
+--
+-- >>> let withTyVars = FgType_TyConApp (Left "Map") [FgType_TyConApp (Right "k") [], FgType_TyConApp (Right "v") []]
+-- >>> let withoutTyVars = FgType_TyConApp "Map" [FgType_TyConApp "Bool" [], FgType_TyConApp "Int" []]
+-- >>> specializeType withTyVars withoutTyVars
+-- Right (Just (FgType_TyConApp "Map" [FgType_TyConApp "Bool" [],FgType_TyConApp "Int" []],fromList [("k",FgType_TyConApp "Bool" []),("v",FgType_TyConApp "Int" [])]))
+--
+--   Example 2: Map a a / Map Bool Bool: [a ~ Bool]
+--
+-- >>> let withTyVars = FgType_TyConApp (Left "Map") [FgType_TyConApp (Right "a") [], FgType_TyConApp (Right "a") []]
+-- >>> let withoutTyVars = FgType_TyConApp "Map" [FgType_TyConApp "Bool" [], FgType_TyConApp "Bool" []]
+-- >>> specializeType withTyVars withoutTyVars
+-- Right (Just (FgType_TyConApp "Map" [FgType_TyConApp "Bool" [],FgType_TyConApp "Bool" []],fromList [("a",FgType_TyConApp "Bool" [])]))
+--
+--   Example 2: Map a a / Map Bool Int: (no match because Bool and Int are different types)
+--
+-- >>> let withTyVars = FgType_TyConApp (Left "Map") [FgType_TyConApp (Right "a") [], FgType_TyConApp (Right "a") []]
+-- >>> let withoutTyVars = FgType_TyConApp "Map" [FgType_TyConApp "Bool" [], FgType_TyConApp "Int" []]
+-- >>> specializeType withTyVars withoutTyVars
+-- Right Nothing
+--
+--   Example 2: f a b / Map Bool Int:
+--
+-- >>> let withTyVars = FgType_TyConApp (Right "f") [FgType_TyConApp (Right "a") [], FgType_TyConApp (Right "b") []]
+-- >>> let withoutTyVars = FgType_TyConApp "Map" [FgType_TyConApp "Bool" [], FgType_TyConApp "Int" []]
+-- >>> specializeType withTyVars withoutTyVars
+-- Right (Just (FgType_TyConApp "Map" [FgType_TyConApp "Bool" [],FgType_TyConApp "Int" []],fromList [("a",FgType_TyConApp "Bool" []),("b",FgType_TyConApp "Int" []),("f",FgType_TyConApp "Map" [])]))
+
+specializeType
+  :: forall tyCon tyVar.
+     ( Eq tyCon
+     , Eq tyVar
+     , Ord tyVar
+     , Show tyCon
+     , Show tyVar
+     )
+  => FgType (Either tyCon tyVar)
+     -- ^ (a) Type with type variables
+  -> FgType tyCon
+     -- ^ (b) Type without type variables
+  -> Either String (Maybe (FgType tyCon, Map tyVar (FgType tyCon)))
+     -- ^ If (b) is a specialization of (a) then this is a 'Just'
+     --    with each type variable in (a) instantiated to a type in (b).
+     --
+     --   A 'Left' denotes an bug somewhere.
+specializeType =
+  go mempty
+  where
+    go :: Map tyVar (FgType tyCon)
+       -> _
+       -> _
+       -> Either String (Maybe (FgType tyCon, Map tyVar (FgType tyCon)))
+    go env poly mono =
+      let handleTyConWithArgs' = handleTyConWithArgs (poly, mono) env
+      in case (poly, mono) of
+        (FgType_TyConApp pTyCon pArgs, FgType_TyConApp mTyCon mArgs) -> -- (Map k v) (Map Bool Int)
+          handleTyConWithArgs' (pTyCon, pArgs) (mTyCon, mArgs)
+
+        (FgType_TyConApp _ _, _) ->
+          Right Nothing
+
+        (FgType_List _, FgType_List _) -> -- [a] [Bool]
+          undefined
+
+        (FgType_List _, _) ->
+          Right Nothing
+
+        (FgType_Tuple _ _ _, FgType_Tuple _ _ _) -> -- (a, b) (a, Bool)
+          undefined
+
+        (FgType_Tuple _ _ _, _) ->
+          Right Nothing
+
+        (FgType_Unit _, _) ->
+          Right Nothing
+
+    handleTyConWithArgs
+      :: forall env.
+         env ~ Map tyVar (FgType tyCon)
+      => (FgType (Either tyCon tyVar), FgType tyCon) -- For debug printing
+      -> env
+      -> (Either tyCon tyVar, [FgType (Either tyCon tyVar)]) -- polymorphic (TyCon, TyCon args)
+      -> (tyCon, [FgType tyCon]) -- monomorphic (TyCon, TyCon args)
+      -> Either String (Maybe (FgType tyCon, env))
+    handleTyConWithArgs dbg env_ (pTyCon, pArgs) (mTyCon, mArgs) =
+      let matchTyConArg
+            :: Maybe ([FgType tyCon], env)
+            -> (FgType (Either tyCon tyVar), FgType tyCon)
+            -> Either String (Maybe ([FgType tyCon], env))
+          matchTyConArg state (poly', mono') = case state of
+            Just (args, env) -> do
+              mFgTypePair <- go env poly' mono'
+              pure $ do
+                (fgTypePair, env') <- mFgTypePair
+                Just (fgTypePair : args, env')
+            other -> pure other
+
+          eTyConArgsResult env'
+            | length mArgs /= length pArgs =
+                Left $ "unsaturated type constructor. " <> show dbg
+            | otherwise =
+                foldM matchTyConArg (Just ([], env')) (zip pArgs mArgs)
+
+          mTyCon'
+            | pTyCon == Left mTyCon =
+                Just (mTyCon, env_) -- both lhs and rhs are the same type constructor.
+            | Right tyVar <- pTyCon = -- lhs is tyvar
+                let blahType = FgType_TyConApp mTyCon [] -- WIP: name
+                in case Map.lookup tyVar env_ of
+                  Just existingTypeEq ->
+                    if existingTypeEq == blahType
+                      then Just (mTyCon, env_) -- previously instantiated to the same type. NOTE: unless `mArgs == []` this is a type variable _NOT_ of kind *
+                      else Nothing -- this type variable was previously instantiated to something else
+                  Nothing ->
+                    Just (mTyCon, Map.insert tyVar blahType env_)
+            | otherwise =
+                Nothing -- lhs and rhs are different type constructors
+      in case mTyCon' of
+        Just (tyCon', env') -> do
+          mResultArgs <- eTyConArgsResult env'
+          Right $ do
+            (resultArgs, env'') <- mResultArgs
+            Just (FgType_TyConApp tyCon' (reverse resultArgs), env'')
+        _ -> Right Nothing

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -7,7 +7,6 @@
 {-# HLINT ignore "Use <$>" #-}
 {-# LANGUAGE TypeOperators #-}
 {-# HLINT ignore "Use first" #-}
-{-# LANGUAGE LambdaCase #-}
 module Types.Doodle
 ( FunctionTypeForallSpecialized(..)
 , FunctionTypeForall
@@ -291,7 +290,7 @@ specializeType =
       -> [FgType (Either tyCon tyVar)] -- polymorphic TyCon args
       -> [FgType tyCon] -- monomorphic TyCon args
       -> Either String (Maybe ([FgType tyCon], env))
-    handleTyConArgs dbg env_ pArgs mArgs =
+    handleTyConArgs _ env_ pArgs mArgs =
       let matchTyConArg
             :: Maybe ([FgType tyCon], env)
             -> (FgType (Either tyCon tyVar), FgType tyCon)

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -11,7 +11,7 @@ type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
 
 data FunctionTypeForall tyVar text = FunctionTypeForall
-  { ftf_forall :: Forall T.Text
+  { ftf_forall :: Forall tyVar
   , ftf_arg :: FgType (Either (FgTyCon text) (TyVar tyVar))
   , ftf_ret :: FgType (Either (FgTyCon text) (TyVar tyVar))
   }

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -7,6 +7,7 @@
 {-# HLINT ignore "Use <$>" #-}
 {-# LANGUAGE TypeOperators #-}
 {-# HLINT ignore "Use first" #-}
+{-# LANGUAGE LambdaCase #-}
 module Types.Doodle
 ( FunctionTypeForallSpecialized(..)
 , FunctionTypeForall
@@ -23,6 +24,8 @@ import qualified Data.Map as Map
 import Control.Monad (foldM)
 import Data.Bifunctor (first)
 import Data.Functor ((<&>))
+import Data.Foldable (foldl')
+import Data.Maybe (fromMaybe)
 
 type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
@@ -43,25 +46,40 @@ data FunctionTypeForallSpecialized tyVar tyVarAssoc text = FunctionTypeForallSpe
   }
 
 -- WIP: name?
-specializationEnvToFunctionTypeForall
-  :: Map tyVar (FgType tyCon)
-  -> FunctionTypeForallSpecialized tyVar tyVarAssoc text
-specializationEnvToFunctionTypeForall =
-  undefined
+specializationEnvToForallSpecialized
+  :: Map (TyVar tyVar) (FgType tyCon)
+  -> ForallSpecialized tyVar ()
+  -> Maybe (ForallSpecialized tyVar (FgType tyCon)) -- Nothing: not all type variables specialized ()
+specializationEnvToForallSpecialized env forallSpecialized =
+  error "WIP"
 
 functionTypeForallToSpecializedFgType
-  :: FunctionTypeForallSpecialized tyVar (FgType tyCon) text
-  -> FgType tyCon
-functionTypeForallToSpecializedFgType =
-  undefined
+  :: ForallSpecialized (TyVar tyVar) (FgType (FgTyCon T.Text))
+  -> FgType (Either (FgTyCon T.Text) (TyVar tyVar))
+  -> Either (ForallError (TyVar tyVar)) (FgType (FgTyCon T.Text)) -- WIP: accumulate _all_ ForallErrors
+functionTypeForallToSpecializedFgType forallSpecialized fgTypePoly = joinFgType <$>
+  traverse
+    (\eitherFgTyConOrTyVar ->
+        either
+          (\tyCon -> Right $ FgType_TyConApp tyCon [])
+          (\tyVar -> do
+              (_, blah) <- lookupTyVarAssoc tyVar forallSpecialized
+              Right blah
+          )
+          eitherFgTyConOrTyVar
+    )
+    fgTypePoly
 
--- |
+-- | Extend from the return type of the monomorphic function
+--
+-- NOTE: quadratic!
 extendFrom
-  :: [FunctionTypeNoTyVar]
+  :: (Ord tyVar, Show tyVar)
+  => [FunctionTypeNoTyVar]
       -- ^ monomorphic functions.
       --
       --   e.g. @Int -> [Bool]@
-  -> [FunctionTypeForall tyVar text]
+  -> [FunctionTypeForall tyVar T.Text]
       -- ^ polymorphic functions
       --
       --   e.g. @forall a. [a] -> Maybe a@
@@ -70,8 +88,33 @@ extendFrom
       --    that takes as argument a type retuned by one of the monomorphic functions
       --
       --  e.g. @[Bool] -> Maybe Bool@
-extendFrom =
-  undefined
+extendFrom monoFuns polyFuns =
+  concat $ foldl' foldFun [] monoFuns
+  where
+    foldFun
+      :: [[FunctionTypeNoTyVar]]
+      -> FunctionTypeNoTyVar
+      -> [[FunctionTypeNoTyVar]]
+    foldFun accum monoFun =
+      let foldFun' accum' polyFun =
+            case specializeType (ftf_arg polyFun) (functionType_ret monoFun) of
+              Right (Just (fgTypePolyArg, env)) ->
+                let mForallSpecialized =
+                      specializationEnvToForallSpecialized env (ftf_forall polyFun)
+                    forallSpecialized = fromMaybe (error $ "WIP: not all type variables specialized in " <> show (env, ftf_forall polyFun)) $
+                      mForallSpecialized
+                    eFgTypePolyRet =
+                      functionTypeForallToSpecializedFgType forallSpecialized (ftf_ret polyFun)
+                    fgTypePolyRet =
+                      either (error . (<> show (forallSpecialized, ftf_ret polyFun)) . show) id eFgTypePolyRet -- WIP
+                in FunctionType
+                  { functionType_arg = fgTypePolyArg
+                  , functionType_ret = fgTypePolyRet
+                  } : accum'
+              Left e ->
+                error e : accum' -- WIP
+              _ -> accum'
+      in foldl' foldFun' [] polyFuns : accum
 
 -- | TODO
 --
@@ -256,8 +299,8 @@ specializeType =
             other -> pure other
 
           eTyConArgsResult env'
-            | length mArgs /= length pArgs = -- WIP: do we handle this now?
-                Left $ "unsaturated type constructor. " <> show dbg
+            | length mArgs /= length pArgs =
+                Right Nothing
             | otherwise =
                 foldM matchTyConArg (Just ([], env')) (zip pArgs mArgs)
       in do

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -13,11 +13,13 @@ module Types.Doodle
 , FunctionTypeForall
 , specializeType
 , mkFunctionTypeForall
+, extendFrom
 )
 where
 
 import Types
 import Types.Forall
+import qualified Types.Forall as Forall
 import Json
 import qualified Data.Text as T
 import qualified Data.Map as Map
@@ -25,7 +27,7 @@ import Control.Monad (foldM)
 import Data.Bifunctor (first)
 import Data.Functor ((<&>))
 import Data.Foldable (foldl')
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, fromJust)
 
 type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
@@ -45,34 +47,38 @@ data FunctionTypeForallSpecialized tyVar tyVarAssoc text = FunctionTypeForallSpe
   , ftf_ret :: FgType (Either (FgTyCon text) (TyVar tyVar))
   }
 
--- WIP: name?
+-- WIP: something more type safe than this conversion
 specializationEnvToForallSpecialized
-  :: Map (TyVar tyVar) (FgType tyCon)
+  :: Ord tyVar
+  => Map (TyVar tyVar) (FgType tyCon)
   -> ForallSpecialized tyVar ()
   -> Maybe (ForallSpecialized tyVar (FgType tyCon)) -- Nothing: not all type variables specialized ()
 specializationEnvToForallSpecialized env forallSpecialized =
-  error "WIP"
+  const (fromJust <$> forallMaybeValue) <$> theMaybe
+  where
+    theMaybe = sequence_ $ Forall.elems forallMaybeValue
+    forallMaybeValue = mapWithKey f forallSpecialized
+    f tyVar () = Map.lookup tyVar env
 
 functionTypeForallToSpecializedFgType
-  :: ForallSpecialized (TyVar tyVar) (FgType (FgTyCon T.Text))
+  :: (Ord tyVar, Show tyVar)
+  => ForallSpecialized tyVar (FgType (FgTyCon T.Text))
   -> FgType (Either (FgTyCon T.Text) (TyVar tyVar))
   -> Either (ForallError (TyVar tyVar)) (FgType (FgTyCon T.Text)) -- WIP: accumulate _all_ ForallErrors
-functionTypeForallToSpecializedFgType forallSpecialized fgTypePoly = joinFgType <$>
+functionTypeForallToSpecializedFgType forallSpecialized fgTypePoly =
+  joinFgType <$>
   traverse
     (\eitherFgTyConOrTyVar ->
         either
           (\tyCon -> Right $ FgType_TyConApp tyCon [])
-          (\tyVar -> do
-              (_, blah) <- lookupTyVarAssoc tyVar forallSpecialized
-              Right blah
-          )
+          (\tyVar -> Right $ snd $ lookupTyVarAssoc tyVar forallSpecialized)
           eitherFgTyConOrTyVar
     )
     fgTypePoly
 
 -- | Extend from the return type of the monomorphic function
 --
--- NOTE: quadratic!
+-- NOTE: quadratic!!!
 extendFrom
   :: (Ord tyVar, Show tyVar)
   => [FunctionTypeNoTyVar]
@@ -84,7 +90,7 @@ extendFrom
       --
       --   e.g. @forall a. [a] -> Maybe a@
   -> [FunctionTypeNoTyVar]
-      -- ^ a list of: a specialization of a polymorphic function
+      -- ^ a list of: a specialization of one of the polymorphic functions
       --    that takes as argument a type retuned by one of the monomorphic functions
       --
       --  e.g. @[Bool] -> Maybe Bool@

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -11,7 +11,7 @@ type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
 
 data FunctionTypeForall tyVar text = FunctionTypeForall
-  { ftf_forall :: Forall T.Text
+  { ftf_forall :: Forall text
   , ftf_arg :: FgType (Either (FgTyCon text) (TyVar tyVar))
   , ftf_ret :: FgType (Either (FgTyCon text) (TyVar tyVar))
   }

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -8,8 +8,10 @@
 {-# LANGUAGE TypeOperators #-}
 {-# HLINT ignore "Use first" #-}
 module Types.Doodle
-( FunctionTypeForall(..)
+( FunctionTypeForallSpecialized(..)
+, FunctionTypeForall
 , specializeType
+, mkFunctionTypeForall
 )
 where
 
@@ -17,7 +19,6 @@ import Types
 import Types.Forall
 import Json
 import qualified Data.Text as T
-import Data.Foldable (foldl')
 import qualified Data.Map as Map
 import Control.Monad (foldM)
 import Data.Bifunctor (first)
@@ -26,11 +27,33 @@ import Data.Functor ((<&>))
 type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
 
-data FunctionTypeForall tyVar text = FunctionTypeForall
-  { ftf_forall :: Forall tyVar
+type FunctionTypeForall tyVar text = FunctionTypeForallSpecialized tyVar () text
+
+mkFunctionTypeForall
+  :: ForallSpecialized tyVar tyVarAssoc
+  -> FgType (Either (FgTyCon text) (TyVar tyVar))
+  -> FgType (Either (FgTyCon text) (TyVar tyVar))
+  -> FunctionTypeForallSpecialized tyVar tyVarAssoc text
+mkFunctionTypeForall = FunctionTypeForallSpecialized
+
+data FunctionTypeForallSpecialized tyVar tyVarAssoc text = FunctionTypeForallSpecialized
+  { ftf_forall :: ForallSpecialized tyVar tyVarAssoc
   , ftf_arg :: FgType (Either (FgTyCon text) (TyVar tyVar))
   , ftf_ret :: FgType (Either (FgTyCon text) (TyVar tyVar))
   }
+
+-- WIP: name?
+specializationEnvToFunctionTypeForall
+  :: Map tyVar (FgType tyCon)
+  -> FunctionTypeForallSpecialized tyVar tyVarAssoc text
+specializationEnvToFunctionTypeForall =
+  undefined
+
+functionTypeForallToSpecializedFgType
+  :: FunctionTypeForallSpecialized tyVar (FgType tyCon) text
+  -> FgType tyCon
+functionTypeForallToSpecializedFgType =
+  undefined
 
 -- |
 extendFrom

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -7,12 +7,18 @@
 {-# HLINT ignore "Use <$>" #-}
 {-# LANGUAGE TypeOperators #-}
 {-# HLINT ignore "Use first" #-}
+{-# LANGUAGE LambdaCase #-}
 module Types.Doodle
 ( FunctionTypeForallSpecialized(..)
 , FunctionTypeForall
 , specializeType
 , mkFunctionTypeForall
 , extendFrom
+  -- * SomeFunction
+, SomeFunction(..)
+, eitherToSomeFunction
+, someFunctionMonomorphic
+, someFunctionPolymorphic
 )
 where
 
@@ -314,3 +320,30 @@ specializeType =
           (resultArgs, env'') <- mResultArgs
           Just (reverse resultArgs, env'')
 
+-- ####################################
+-- ########### SomeFunction ###########
+-- ####################################
+
+data SomeFunction
+  = SomeFunction_Monomorphic (FunctionType (FgType (FgTyCon T.Text)))
+  | SomeFunction_Polymorphic (FunctionTypeForall T.Text T.Text)
+
+eitherToSomeFunction
+  :: Either
+      (Json.FunctionType (FgType (FgTyCon T.Text)))
+      (FunctionTypeForall T.Text T.Text)
+  -> SomeFunction
+eitherToSomeFunction =
+  either SomeFunction_Monomorphic SomeFunction_Polymorphic
+
+someFunctionMonomorphic
+  :: SomeFunction -> Maybe (FunctionType (FgType (FgTyCon T.Text)))
+someFunctionMonomorphic = \case
+  SomeFunction_Monomorphic mono -> Just mono
+  SomeFunction_Polymorphic _ -> Nothing
+
+someFunctionPolymorphic
+  :: SomeFunction -> Maybe (FunctionTypeForall T.Text T.Text)
+someFunctionPolymorphic = \case
+  SomeFunction_Polymorphic poly -> Just poly
+  SomeFunction_Monomorphic _ -> Nothing

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# HLINT ignore "Use first" #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Types.Doodle
 ( FunctionTypeForallSpecialized(..)
 , FunctionTypeForall
@@ -19,20 +20,28 @@ module Types.Doodle
 , eitherToSomeFunction
 , someFunctionMonomorphic
 , someFunctionPolymorphic
+  -- * `FgError`
+, FgError(..)
+, renderFgError
 )
 where
 
 import Types
 import Types.Forall
 import qualified Types.Forall as Forall
-import Json
+-- import Json
 import qualified Data.Text as T
+import Data.Map (Map)
 import qualified Data.Map as Map
 import Control.Monad (foldM)
 import Data.Bifunctor (first)
 import Data.Functor ((<&>))
 import Data.Foldable (foldl')
 import Data.Maybe (fromMaybe, fromJust)
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import qualified Data.Aeson as A
+import Data.String (fromString)
 
 type FunctionTypeNoTyVar =
   FunctionType (FgType (FgTyCon T.Text))
@@ -50,7 +59,11 @@ data FunctionTypeForallSpecialized tyVar tyVarAssoc text = FunctionTypeForallSpe
   { ftf_forall :: ForallSpecialized tyVar tyVarAssoc
   , ftf_arg :: FgType (Either (FgTyCon text) (TyVar tyVar))
   , ftf_ret :: FgType (Either (FgTyCon text) (TyVar tyVar))
-  }
+  } deriving (Eq, Show, Ord, Generic)
+
+instance (NFData tyVar, NFData tyVarAssoc, NFData text) => NFData (FunctionTypeForallSpecialized tyVar tyVarAssoc text)
+instance (A.ToJSON tyVar, A.ToJSONKey tyVar, A.ToJSON tyVarAssoc, A.ToJSON text) => A.ToJSON (FunctionTypeForallSpecialized tyVar tyVarAssoc text)
+instance (A.FromJSON tyVar, A.FromJSONKey tyVar, Ord tyVar, A.FromJSON tyVarAssoc, A.FromJSON text) => A.FromJSON (FunctionTypeForallSpecialized tyVar tyVarAssoc text)
 
 -- WIP: something more type safe than this conversion
 specializationEnvToForallSpecialized
@@ -324,13 +337,19 @@ specializeType =
 -- ########### SomeFunction ###########
 -- ####################################
 
+-- WIP: take `text` type arg?
 data SomeFunction
   = SomeFunction_Monomorphic (FunctionType (FgType (FgTyCon T.Text)))
   | SomeFunction_Polymorphic (FunctionTypeForall T.Text T.Text)
+      deriving (Eq, Show, Ord, Generic)
+
+instance NFData SomeFunction
+instance A.ToJSON SomeFunction
+instance A.FromJSON SomeFunction
 
 eitherToSomeFunction
   :: Either
-      (Json.FunctionType (FgType (FgTyCon T.Text)))
+      (FunctionType (FgType (FgTyCon T.Text)))
       (FunctionTypeForall T.Text T.Text)
   -> SomeFunction
 eitherToSomeFunction =
@@ -347,3 +366,25 @@ someFunctionPolymorphic
 someFunctionPolymorphic = \case
   SomeFunction_Polymorphic poly -> Just poly
   SomeFunction_Monomorphic _ -> Nothing
+
+data FgError
+  = FgError_Forall (Forall.ForallError T.Text)
+  | FgError_TyCon TyConParseError
+    -- ^ An error occurred converting a 'GHC.Core.TyCon.TyCon' into a 'FgTyCon'.
+    --   This is probably a bug in 'Types.parsePprTyCon'.
+      deriving (Eq, Show, Ord, Generic)
+
+instance A.ToJSON FgError
+instance A.FromJSON FgError
+instance NFData FgError
+
+-- | Render a 'FgError' as a human-readable text string
+renderFgError
+  :: FgError
+  -> T.Text
+renderFgError = \case
+  FgError_TyCon e -> renderTyConParseError e
+  FgError_Forall e -> T.unwords
+    [ fromString "WIP:"
+    , T.pack $ show e
+    ]

--- a/dump-decls-lib/src/Types/Doodle.hs
+++ b/dump-decls-lib/src/Types/Doodle.hs
@@ -23,6 +23,8 @@ module Types.Doodle
   -- * `FgError`
 , FgError(..)
 , renderFgError
+, renderFunctionTypeForallGeneric
+, renderSomeFunctionType
 )
 where
 
@@ -37,7 +39,7 @@ import Control.Monad (foldM)
 import Data.Bifunctor (first)
 import Data.Functor ((<&>))
 import Data.Foldable (foldl')
-import Data.Maybe (fromMaybe, fromJust)
+import Data.Maybe (fromJust)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import qualified Data.Aeson as A
@@ -54,6 +56,32 @@ mkFunctionTypeForall
   -> FgType (Either (FgTyCon text) (TyVar tyVar))
   -> FunctionTypeForallSpecialized tyVar tyVarAssoc text
 mkFunctionTypeForall = FunctionTypeForallSpecialized
+
+renderFunctionTypeForallUnqualified
+  :: Show tyVar
+  => FunctionTypeForall tyVar T.Text
+  -> T.Text
+renderFunctionTypeForallUnqualified =
+  renderFunctionTypeForallGeneric
+    (T.pack . read . show) -- WIP
+    renderFgTyConUnqualified
+
+renderFunctionTypeForallGeneric
+  :: forall tyVar.
+     (tyVar -> T.Text)
+  -> (FgTyCon T.Text -> T.Text)
+  -> FunctionTypeForall tyVar T.Text
+  -> T.Text
+renderFunctionTypeForallGeneric renderTyVar renderFgTyCon ftf = T.unwords
+  [ Forall.renderForall renderTyVar $ ftf_forall ftf
+  , renderFgType' $ ftf_arg ftf
+  , fromString "->"
+  , renderFgType' $ ftf_ret ftf
+  ]
+  where
+    renderFgType' :: FgType (Either (FgTyCon T.Text) (Forall.TyVar tyVar)) -> T.Text
+    renderFgType' =
+      renderFgType (either renderFgTyCon (renderTyVar . Forall.getTyVar))
 
 data FunctionTypeForallSpecialized tyVar tyVarAssoc text = FunctionTypeForallSpecialized
   { ftf_forall :: ForallSpecialized tyVar tyVarAssoc
@@ -98,16 +126,17 @@ functionTypeForallToSpecializedFgType forallSpecialized fgTypePoly =
 --
 -- NOTE: quadratic!!!
 extendFrom
-  :: (Ord tyVar, Show tyVar)
-  => [FunctionTypeNoTyVar]
+  :: forall tyVar meta.
+     (Ord tyVar, Show tyVar, Show meta)
+  => [(meta, FunctionTypeNoTyVar)]
       -- ^ monomorphic functions.
       --
       --   e.g. @Int -> [Bool]@
-  -> [FunctionTypeForall tyVar T.Text]
+  -> [(meta, FunctionTypeForall tyVar T.Text)]
       -- ^ polymorphic functions
       --
       --   e.g. @forall a. [a] -> Maybe a@
-  -> [FunctionTypeNoTyVar]
+  -> [((meta, meta), Either String FunctionTypeNoTyVar)]
       -- ^ a list of: a specialization of one of the polymorphic functions
       --    that takes as argument a type retuned by one of the monomorphic functions
       --
@@ -116,27 +145,39 @@ extendFrom monoFuns polyFuns =
   concat $ foldl' foldFun [] monoFuns
   where
     foldFun
-      :: [[FunctionTypeNoTyVar]]
-      -> FunctionTypeNoTyVar
-      -> [[FunctionTypeNoTyVar]]
-    foldFun accum monoFun =
-      let foldFun' accum' polyFun =
+      :: [[((meta, meta), Either String FunctionTypeNoTyVar)]]
+      -> (meta, FunctionTypeNoTyVar)
+      -> [[((meta, meta), Either String FunctionTypeNoTyVar)]]
+    foldFun accum (monoMeta, monoFun) =
+      let foldFun' accum' (polyMeta, polyFun) =
             case specializeType (ftf_arg polyFun) (functionType_ret monoFun) of
               Right (Just (fgTypePolyArg, env)) ->
                 let mForallSpecialized =
                       specializationEnvToForallSpecialized env (ftf_forall polyFun)
-                    forallSpecialized = fromMaybe (error $ "WIP: not all type variables specialized in " <> show (env, ftf_forall polyFun)) $
+                    eForallSpecialized = maybe
+                      (Left $ unwords
+                        [ "WIP: Not all type variables specialized in"
+                        , "'" <> T.unpack (renderFunctionTypeForallUnqualified polyFun) <> "'."
+                        , "Env: " <> (show . Map.assocs) (Map.mapKeys getTyVar $ renderFgType renderFgTyConUnqualified <$> env) <> "." --
+                        ]
+                      )
+                      Right
                       mForallSpecialized
-                    eFgTypePolyRet =
+                    eMkFgTypePolyRet forallSpecialized =
                       functionTypeForallToSpecializedFgType forallSpecialized (ftf_ret polyFun)
-                    fgTypePolyRet =
-                      either (error . (<> show (forallSpecialized, ftf_ret polyFun)) . show) id eFgTypePolyRet -- WIP
-                in FunctionType
-                  { functionType_arg = fgTypePolyArg
-                  , functionType_ret = fgTypePolyRet
-                  } : accum'
+                    renderError forallSpecialized =
+                      (<> show (forallSpecialized, ftf_ret polyFun)) . show
+                    mkFt fgTypePolyRet' = FunctionType
+                      { functionType_arg = fgTypePolyArg
+                      , functionType_ret = fgTypePolyRet'
+                      }
+                    eFt = do
+                      forallSpecialized <- eForallSpecialized
+                      fgTypePolyRet <- first (renderError forallSpecialized) $ eMkFgTypePolyRet forallSpecialized
+                      Right $ mkFt fgTypePolyRet
+                in ((monoMeta, polyMeta), eFt) : accum'
               Left e ->
-                error e : accum' -- WIP
+                ((monoMeta, polyMeta), Left e) : accum' -- WIP
               _ -> accum'
       in foldl' foldFun' [] polyFuns : accum
 
@@ -338,6 +379,7 @@ specializeType =
 -- ####################################
 
 -- WIP: take `text` type arg?
+-- TODO: rename to `SomeFunctionType`?
 data SomeFunction
   = SomeFunction_Monomorphic (FunctionType (FgType (FgTyCon T.Text)))
   | SomeFunction_Polymorphic (FunctionTypeForall T.Text T.Text)
@@ -347,6 +389,26 @@ instance NFData SomeFunction
 instance A.ToJSON SomeFunction
 instance A.FromJSON SomeFunction
 
+-- WIP
+renderSomeFunctionType
+  :: SomeFunction
+  -> T.Text
+renderSomeFunctionType =
+  renderSomeFunctionTypeGeneric
+    (T.pack . read . show) -- WIP
+    renderFgTyConQualifiedNoPackage
+
+renderSomeFunctionTypeGeneric
+  :: _
+  -> _
+  -> SomeFunction
+  -> T.Text
+renderSomeFunctionTypeGeneric renderTyVar renderTyCon =
+  either
+    (renderFunctionTypeMonoGeneric renderTyCon)
+    (renderFunctionTypeForallGeneric renderTyVar renderTyCon)
+  . someFunctionToEither
+
 eitherToSomeFunction
   :: Either
       (FunctionType (FgType (FgTyCon T.Text)))
@@ -355,14 +417,25 @@ eitherToSomeFunction
 eitherToSomeFunction =
   either SomeFunction_Monomorphic SomeFunction_Polymorphic
 
+someFunctionToEither
+  :: SomeFunction
+  -> Either
+      (FunctionType (FgType (FgTyCon T.Text)))
+      (FunctionTypeForall T.Text T.Text)
+someFunctionToEither = \case
+  SomeFunction_Monomorphic a -> Left a
+  SomeFunction_Polymorphic b -> Right b
+
 someFunctionMonomorphic
-  :: SomeFunction -> Maybe (FunctionType (FgType (FgTyCon T.Text)))
+  :: SomeFunction
+  -> Maybe (FunctionType (FgType (FgTyCon T.Text)))
 someFunctionMonomorphic = \case
   SomeFunction_Monomorphic mono -> Just mono
   SomeFunction_Polymorphic _ -> Nothing
 
 someFunctionPolymorphic
-  :: SomeFunction -> Maybe (FunctionTypeForall T.Text T.Text)
+  :: SomeFunction
+  -> Maybe (FunctionTypeForall T.Text T.Text)
 someFunctionPolymorphic = \case
   SomeFunction_Polymorphic poly -> Just poly
   SomeFunction_Monomorphic _ -> Nothing

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -4,16 +4,19 @@ module Types.Forall
   Forall
 , TyVar
   -- * Operations
-, singleton, appendTyVar
+, singleton, appendTyVar, renderForall
 , getTyVar, lookupTyVar
   -- * Errors
 , ForallError(..)
 )
 where
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
+import Data.Foldable (toList)
+import Data.String (fromString)
 
 -- TODO
-type OrdSet a = ()
+type OrdSet a = [a]
 
 -- | Represents the @forall@-part of a type signature, which has the form
 --   @forall x1 x2 x3 [...] xn.@.
@@ -21,6 +24,13 @@ type OrdSet a = ()
 --   This part of the type signature /introduces/ type variables, which are
 --   then referenced in the part of the type signature that follows.
 newtype Forall tyVar = Forall (OrdSet tyVar)
+
+renderForall
+  :: (tyVar -> T.Text)
+  -> Forall tyVar
+  -> T.Text
+renderForall renderTyVar (Forall ordSet) =
+    T.unwords (fromString "forall" : map renderTyVar (toList ordSet)) <> fromString "."
 
 -- | Represents a type variable in a type signature, e.g. the
 --   last two occurrences of @a@ in @forall a. a -> a@.

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE RankNTypes #-} -- TODO: remove
+module Types.Forall
+( -- * Types
+  Forall
+, TyVar
+  -- * Operations
+, singleton, appendTyVar
+, getTyVar, lookupTyVar
+  -- * Errors
+, ForallError(..)
+)
+where
+import qualified Data.List.NonEmpty as NE
+
+-- TODO
+type OrdSet a = ()
+
+-- | Represents the @forall@-part of a type signature, which has the form
+--   @forall x1 x2 x3 [...] xn.@.
+--
+--   This part of the type signature /introduces/ type variables, which are
+--   then referenced in the part of the type signature that follows.
+newtype Forall tyVar = Forall (OrdSet tyVar)
+
+-- | Represents a type variable in a type signature, e.g. the
+--   last two occurrences of @a@ in @forall a. a -> a@.
+--
+--   This part of the type signature /references/ type variables introduced
+--   by the @forall@ part of the type signature.
+newtype TyVar tyVar = TyVar { unTyVar :: tyVar }
+
+getTyVar :: TyVar tyVar -> tyVar
+getTyVar = unTyVar
+
+singleton
+  :: tyVar
+  -> Forall tyVar
+singleton = error "TODO"
+
+-- | Append a type variable to the end of the list of type variables in a @forall@
+appendTyVar
+  :: tyVar
+  -> Forall tyVar
+  -> Either (ForallError tyVar) (Forall tyVar)
+appendTyVar = error "TODO"
+
+lookupTyVar
+  :: tyVar
+  -> Forall tyVar
+  -> Either (ForallError tyVar) (TyVar tyVar)
+lookupTyVar = error "TODO"
+
+data ForallError tyVar
+  = DuplicateTypeVar -- ^ 'appendTyVar' was called attempting to introduce a type variable that already exists
+      (NE.NonEmpty tyVar) -- ^ Existing type variables
+      tyVar -- ^ New type variable (contained within the existing type variables)
+  | NoSuchTypeVar -- ^ TODO:
+      (NE.NonEmpty tyVar)
+      tyVar
+  deriving (Eq, Show)

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RankNTypes #-} -- TODO: remove
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Types.Forall
 ( -- * Types
   Forall
@@ -8,9 +9,10 @@ module Types.Forall
 , TyVar
   -- * Operations
 , singleton, appendTyVar, renderForall
-, getTyVar, lookupTyVar, lookupTyVarAssoc
+, getTyVar, lookupTyVar, lookupTyVarAssocM, lookupTyVarAssoc
+, mapWithKey, elems
   -- * Errors
-, ForallError(..), mapWithKey
+, ForallError(..)
 )
 where
 import qualified Data.List.NonEmpty as NE
@@ -18,6 +20,8 @@ import qualified Data.Text as T
 import Data.Map.Ordered.Strict (OMap, (<|))
 import qualified Data.Map.Ordered.Strict as OMap
 import Data.String (fromString)
+import GHC.Stack (HasCallStack)
+import Data.Functor (void)
 
 -- TODO
 type OrdMap k v = OMap k v
@@ -35,6 +39,12 @@ type Forall tyVar = ForallSpecialized tyVar ()
 
 newtype ForallSpecialized tyVar assoc = ForallSpecialized (OrdMap tyVar assoc)
   deriving (Eq, Show, Ord, Functor, Foldable)
+
+elems
+  :: ForallSpecialized k v
+  -> [v]
+elems (ForallSpecialized ordMap) =
+  snd <$> OMap.assocs ordMap
 
 mapWithKey
   :: Ord tyVar
@@ -86,18 +96,39 @@ lookupTyVar
   -> Forall tyVar
   -> Either (ForallError tyVar) (TyVar tyVar)
 lookupTyVar tyVar  =
-  fmap fst . lookupTyVarAssoc tyVar
+  fmap fst . lookupTyVarAssocM tyVar
 
-lookupTyVarAssoc
+lookupTyVarAssocM
   :: (Ord tyVar)
   => tyVar
   -> ForallSpecialized tyVar assoc
   -> Either (ForallError tyVar) (TyVar tyVar, assoc)
-lookupTyVarAssoc tyVar (ForallSpecialized ordMap) =
+lookupTyVarAssocM tyVar (ForallSpecialized ordMap) =
   maybe
     (Left $ NoSuchTypeVar (NE.fromList $ toOrderedList ordMap) tyVar) -- WIP
     (\assoc -> Right (TyVar tyVar, assoc))
     (OMap.lookup tyVar ordMap)
+
+-- | TODO: The 'TyVar' is a witness that the given type variable exists
+lookupTyVarAssoc
+  :: (HasCallStack, Show tyVar)
+  => (Ord tyVar)
+  => TyVar tyVar
+  -> ForallSpecialized tyVar assoc
+  -> (TyVar tyVar, assoc)
+lookupTyVarAssoc (TyVar tyVar) fs =
+  either
+    (error . T.unpack $ errTxt)
+    id
+  $ lookupTyVarAssocM tyVar fs
+  where
+    errTxt = T.unwords
+      [ "No such tyvar"
+      , T.pack (show tyVar)
+      , "in"
+      , renderForall (T.pack . show) (void fs) <> "."
+      , "This is a bug unless you got the TyVar from applying 'lookupTyVar' to a different 'ForallSpecialized'."
+      ]
 
 data ForallError tyVar
   = DuplicateTypeVar -- ^ 'appendTyVar' was called attempting to introduce a type variable that already exists

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -42,23 +42,35 @@ newtype TyVar tyVar = TyVar { unTyVar :: tyVar }
 getTyVar :: TyVar tyVar -> tyVar
 getTyVar = unTyVar
 
+-- WIP
 singleton
   :: tyVar
   -> Forall tyVar
-singleton = error "TODO"
+singleton tyVar =
+  Forall [tyVar]
 
 -- | Append a type variable to the end of the list of type variables in a @forall@
 appendTyVar
-  :: tyVar
+  :: Eq tyVar
+  => tyVar
   -> Forall tyVar
   -> Either (ForallError tyVar) (Forall tyVar)
-appendTyVar = error "TODO"
+appendTyVar tyVar (Forall ordSet) =
+  -- WIP
+  if tyVar `elem` ordSet
+    then Left $ DuplicateTypeVar (NE.fromList ordSet) tyVar
+    else Right $ Forall (tyVar : ordSet)
 
 lookupTyVar
-  :: tyVar
+  :: Eq tyVar
+  => tyVar
   -> Forall tyVar
   -> Either (ForallError tyVar) (TyVar tyVar)
-lookupTyVar = error "TODO"
+lookupTyVar tyVar (Forall ordSet) =
+  -- WIP
+  if tyVar `elem` ordSet
+    then Right (TyVar tyVar)
+    else Left $ NoSuchTypeVar (NE.fromList ordSet) tyVar
 
 data ForallError tyVar
   = DuplicateTypeVar -- ^ 'appendTyVar' was called attempting to introduce a type variable that already exists

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -27,7 +27,7 @@ type OrdMap k v = OMap k v
 
 -- insertion order
 toOrderedList :: OrdMap tyVar assoc -> [tyVar]
-toOrderedList = map fst . OMap.assocs
+toOrderedList = reverse . map fst . OMap.assocs
 
 -- | Represents the @forall@-part of a type signature, which has the form
 --   @forall x1 x2 x3 [...] xn.@.

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -85,8 +85,8 @@ appendTyVar
   -> Either (ForallError tyVar) (Forall tyVar)
 appendTyVar tyVar (ForallSpecialized ordMap) =
   maybe
-    (Left $ DuplicateTypeVar (NE.fromList $ toOrderedList ordMap) tyVar) -- WIP
-    (const $ Right $ ForallSpecialized $ (tyVar, ()) <| ordMap)
+    (Right $ ForallSpecialized $ (tyVar, ()) <| ordMap)
+    (const $ Left $ DuplicateTypeVar (NE.fromList $ toOrderedList ordMap) tyVar) -- WIP
     (OMap.lookup tyVar ordMap)
 
 lookupTyVar

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE RankNTypes #-} -- TODO: remove
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -27,6 +27,7 @@ toOrderedList = reverse -- TODO use Data.Foldable.toList for the real OSet
 --   This part of the type signature /introduces/ type variables, which are
 --   then referenced in the part of the type signature that follows.
 newtype Forall tyVar = Forall (OrdSet tyVar)
+  deriving (Eq, Show, Ord)
 
 renderForall
   :: (tyVar -> T.Text)
@@ -41,6 +42,7 @@ renderForall renderTyVar (Forall ordSet) =
 --   This part of the type signature /references/ type variables introduced
 --   by the @forall@ part of the type signature.
 newtype TyVar tyVar = TyVar { unTyVar :: tyVar }
+  deriving (Show, Eq, Ord)
 
 getTyVar :: TyVar tyVar -> tyVar
 getTyVar = unTyVar

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -12,11 +12,14 @@ module Types.Forall
 where
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
-import Data.Foldable (toList)
 import Data.String (fromString)
 
 -- TODO
 type OrdSet a = [a]
+
+-- insertion order
+toOrderedList :: OrdSet a -> [a]
+toOrderedList = reverse -- TODO use Data.Foldable.toList for the real OSet
 
 -- | Represents the @forall@-part of a type signature, which has the form
 --   @forall x1 x2 x3 [...] xn.@.
@@ -30,7 +33,7 @@ renderForall
   -> Forall tyVar
   -> T.Text
 renderForall renderTyVar (Forall ordSet) =
-    T.unwords (fromString "forall" : map renderTyVar (toList ordSet)) <> fromString "."
+    T.unwords (fromString "forall" : map renderTyVar (toOrderedList ordSet)) <> fromString "."
 
 -- | Represents a type variable in a type signature, e.g. the
 --   last two occurrences of @a@ in @forall a. a -> a@.

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use fmap" #-}
 module Types.Forall
 ( -- * Types
   Forall
@@ -21,9 +26,26 @@ import qualified Data.Map.Ordered.Strict as OMap
 import Data.String (fromString)
 import GHC.Stack (HasCallStack)
 import Data.Functor (void)
+import Control.DeepSeq (NFData (rnf))
+import GHC.Generics (Generic)
+import qualified Data.Aeson as A
+import qualified Data.Vector as V
 
--- TODO
+-- TODO newtype
 type OrdMap k v = OMap k v
+
+instance (NFData k, NFData v) => NFData (OMap k v) where
+  rnf = rnf . OMap.toAscList
+instance (A.ToJSON k, A.ToJSONKey k, A.ToJSON v) => A.ToJSON (OMap k v) where
+  toJSON = A.toJSON . OMap.assocs
+instance (A.FromJSON k, A.FromJSONKey k, Ord k, A.FromJSON v) => A.FromJSON (OMap k v) where
+  parseJSON =
+    let parseKV = A.withArray "KeyValue" $ \vec ->
+          case V.toList vec of
+            [k, v] -> (,) <$> A.parseJSON k <*> A.parseJSON v
+            other -> fail $ "Expected two-element key-value list. Got: " <> show other
+    in A.withArray "OrdMap" $ \vec ->
+      OMap.fromList . V.toList <$> traverse parseKV vec
 
 -- insertion order
 toOrderedList :: OrdMap tyVar assoc -> [tyVar]
@@ -37,7 +59,12 @@ toOrderedList = reverse . map fst . OMap.assocs
 type Forall tyVar = ForallSpecialized tyVar ()
 
 newtype ForallSpecialized tyVar assoc = ForallSpecialized (OrdMap tyVar assoc)
-  deriving (Eq, Show, Ord, Functor, Foldable)
+  deriving (Eq, Show, Ord, Functor, Foldable, Generic)
+
+instance (NFData tyVar, NFData assoc) => NFData (ForallSpecialized tyVar assoc)
+
+instance (A.ToJSON tyVar, A.ToJSONKey tyVar, A.ToJSON assoc) => A.ToJSON (ForallSpecialized tyVar assoc)
+instance (A.FromJSON tyVar, A.FromJSONKey tyVar, Ord tyVar, A.FromJSON assoc) => A.FromJSON (ForallSpecialized tyVar assoc)
 
 elems
   :: ForallSpecialized k v
@@ -66,7 +93,11 @@ renderForall renderTyVar (ForallSpecialized ordMap) =
 --   This part of the type signature /references/ type variables introduced
 --   by the @forall@ part of the type signature.
 newtype TyVar tyVar = TyVar { unTyVar :: tyVar }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance (NFData tyVar) => NFData (TyVar tyVar)
+instance (A.ToJSON tyVar, A.ToJSONKey tyVar) => A.ToJSON (TyVar tyVar)
+instance (A.FromJSON tyVar, A.FromJSONKey tyVar, Ord tyVar) => A.FromJSON (TyVar tyVar)
 
 getTyVar :: TyVar tyVar -> tyVar
 getTyVar = unTyVar
@@ -136,4 +167,8 @@ data ForallError tyVar
   | NoSuchTypeVar -- ^ TODO:
       (NE.NonEmpty tyVar)
       tyVar
-  deriving (Eq, Show)
+  deriving (Eq, Show, Ord, Generic)
+
+instance (A.ToJSON tyVar, A.ToJSONKey tyVar) => A.ToJSON (ForallError tyVar)
+instance (A.FromJSON tyVar, A.FromJSONKey tyVar, Ord tyVar) => A.FromJSON (ForallError tyVar)
+instance (NFData tyVar) => NFData (ForallError tyVar)

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE RankNTypes #-} -- TODO: remove
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
 module Types.Forall
 ( -- * Types
   Forall
@@ -6,9 +8,9 @@ module Types.Forall
 , TyVar
   -- * Operations
 , singleton, appendTyVar, renderForall
-, getTyVar, lookupTyVar
+, getTyVar, lookupTyVar, lookupTyVarAssoc
   -- * Errors
-, ForallError(..)
+, ForallError(..), mapWithKey
 )
 where
 import qualified Data.List.NonEmpty as NE
@@ -32,7 +34,15 @@ toOrderedList = map fst . OMap.assocs
 type Forall tyVar = ForallSpecialized tyVar ()
 
 newtype ForallSpecialized tyVar assoc = ForallSpecialized (OrdMap tyVar assoc)
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Show, Ord, Functor, Foldable)
+
+mapWithKey
+  :: Ord tyVar
+  => (TyVar tyVar -> assoc -> assoc')
+  -> ForallSpecialized tyVar assoc
+  -> ForallSpecialized tyVar assoc'
+mapWithKey f (ForallSpecialized ordMap) =
+  ForallSpecialized $ OMap.fromList $ map (\(k, v) -> (k, f (TyVar k) v)) $ OMap.assocs ordMap
 
 renderForall
   :: (tyVar -> T.Text)
@@ -75,10 +85,18 @@ lookupTyVar
   => tyVar
   -> Forall tyVar
   -> Either (ForallError tyVar) (TyVar tyVar)
-lookupTyVar tyVar (ForallSpecialized ordMap) =
+lookupTyVar tyVar  =
+  fmap fst . lookupTyVarAssoc tyVar
+
+lookupTyVarAssoc
+  :: (Ord tyVar)
+  => tyVar
+  -> ForallSpecialized tyVar assoc
+  -> Either (ForallError tyVar) (TyVar tyVar, assoc)
+lookupTyVarAssoc tyVar (ForallSpecialized ordMap) =
   maybe
     (Left $ NoSuchTypeVar (NE.fromList $ toOrderedList ordMap) tyVar) -- WIP
-    (const $ Right $ TyVar tyVar)
+    (\assoc -> Right (TyVar tyVar, assoc))
     (OMap.lookup tyVar ordMap)
 
 data ForallError tyVar

--- a/dump-decls-lib/src/Types/Forall.hs
+++ b/dump-decls-lib/src/Types/Forall.hs
@@ -2,6 +2,7 @@
 module Types.Forall
 ( -- * Types
   Forall
+, ForallSpecialized
 , TyVar
   -- * Operations
 , singleton, appendTyVar, renderForall
@@ -12,29 +13,33 @@ module Types.Forall
 where
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
+import Data.Map.Ordered.Strict (OMap, (<|))
+import qualified Data.Map.Ordered.Strict as OMap
 import Data.String (fromString)
 
 -- TODO
-type OrdSet a = [a]
+type OrdMap k v = OMap k v
 
 -- insertion order
-toOrderedList :: OrdSet a -> [a]
-toOrderedList = reverse -- TODO use Data.Foldable.toList for the real OSet
+toOrderedList :: OrdMap tyVar assoc -> [tyVar]
+toOrderedList = map fst . OMap.assocs
 
 -- | Represents the @forall@-part of a type signature, which has the form
 --   @forall x1 x2 x3 [...] xn.@.
 --
 --   This part of the type signature /introduces/ type variables, which are
 --   then referenced in the part of the type signature that follows.
-newtype Forall tyVar = Forall (OrdSet tyVar)
+type Forall tyVar = ForallSpecialized tyVar ()
+
+newtype ForallSpecialized tyVar assoc = ForallSpecialized (OrdMap tyVar assoc)
   deriving (Eq, Show, Ord)
 
 renderForall
   :: (tyVar -> T.Text)
   -> Forall tyVar
   -> T.Text
-renderForall renderTyVar (Forall ordSet) =
-    T.unwords (fromString "forall" : map renderTyVar (toOrderedList ordSet)) <> fromString "."
+renderForall renderTyVar (ForallSpecialized ordMap) =
+    T.unwords (fromString "forall" : map renderTyVar (toOrderedList ordMap)) <> fromString "."
 
 -- | Represents a type variable in a type signature, e.g. the
 --   last two occurrences of @a@ in @forall a. a -> a@.
@@ -47,35 +52,34 @@ newtype TyVar tyVar = TyVar { unTyVar :: tyVar }
 getTyVar :: TyVar tyVar -> tyVar
 getTyVar = unTyVar
 
--- WIP
 singleton
   :: tyVar
   -> Forall tyVar
 singleton tyVar =
-  Forall [tyVar]
+  ForallSpecialized $ OMap.singleton (tyVar, ())
 
 -- | Append a type variable to the end of the list of type variables in a @forall@
 appendTyVar
-  :: Eq tyVar
+  :: (Ord tyVar)
   => tyVar
   -> Forall tyVar
   -> Either (ForallError tyVar) (Forall tyVar)
-appendTyVar tyVar (Forall ordSet) =
-  -- WIP
-  if tyVar `elem` ordSet
-    then Left $ DuplicateTypeVar (NE.fromList ordSet) tyVar
-    else Right $ Forall (tyVar : ordSet)
+appendTyVar tyVar (ForallSpecialized ordMap) =
+  maybe
+    (Left $ DuplicateTypeVar (NE.fromList $ toOrderedList ordMap) tyVar) -- WIP
+    (const $ Right $ ForallSpecialized $ (tyVar, ()) <| ordMap)
+    (OMap.lookup tyVar ordMap)
 
 lookupTyVar
-  :: Eq tyVar
+  :: (Ord tyVar)
   => tyVar
   -> Forall tyVar
   -> Either (ForallError tyVar) (TyVar tyVar)
-lookupTyVar tyVar (Forall ordSet) =
-  -- WIP
-  if tyVar `elem` ordSet
-    then Right (TyVar tyVar)
-    else Left $ NoSuchTypeVar (NE.fromList ordSet) tyVar
+lookupTyVar tyVar (ForallSpecialized ordMap) =
+  maybe
+    (Left $ NoSuchTypeVar (NE.fromList $ toOrderedList ordMap) tyVar) -- WIP
+    (const $ Right $ TyVar tyVar)
+    (OMap.lookup tyVar ordMap)
 
 data ForallError tyVar
   = DuplicateTypeVar -- ^ 'appendTyVar' was called attempting to introduce a type variable that already exists

--- a/nix/shell-deps.nix
+++ b/nix/shell-deps.nix
@@ -4,5 +4,6 @@ with (import ./pkgs.nix);
     pkgsUnstable.cabal-install
     pkgs.git
     pkgs.zlib # needed for building haskell-language-server
+    pkgs.hlint
   ];
 }


### PR DESCRIPTION
## TODO

- [ ] Consumers of `Exe` module: add wrapper that runs `ghc --print-libdir`
   - [ ] make ghc available at runtime for nix-build
- [x] Which type variable kinds to support?
   - [x] Surely `*`
   - [ ] What about `* -> *`?
      * I _think_ these kinds are not useful unless we also support type classes (which we don't, yet)